### PR TITLE
[TNT-117] 이미지 피커 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,14 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/core/ui/src/main/java/co/kr/tnt/ui/coil/ResizeTransformation.kt
+++ b/core/ui/src/main/java/co/kr/tnt/ui/coil/ResizeTransformation.kt
@@ -1,0 +1,37 @@
+package co.kr.tnt.ui.coil
+
+import android.graphics.Bitmap
+import coil.size.Size
+import coil.transform.Transformation
+import java.io.ByteArrayOutputStream
+
+class ResizeTransformation(
+    private val maxSizeInBytes: Int,
+) : Transformation {
+    override val cacheKey: String = "resize_to_max_size_$maxSizeInBytes"
+
+    override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+        var bitmap = input
+        var quality = 100
+
+        while (true) {
+            val byteArrayOutputStream = ByteArrayOutputStream()
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+            val compressedSize = byteArrayOutputStream.size()
+
+            if (compressedSize <= maxSizeInBytes) {
+                break
+            }
+
+            bitmap = Bitmap.createScaledBitmap(
+                bitmap,
+                (bitmap.width * 0.9).toInt(),
+                (bitmap.height * 0.9).toInt(),
+                true,
+            )
+            quality -= 5
+        }
+
+        return bitmap
+    }
+}

--- a/core/ui/src/main/java/co/kr/tnt/ui/permission/PermissionRequestDialog.kt
+++ b/core/ui/src/main/java/co/kr/tnt/ui/permission/PermissionRequestDialog.kt
@@ -45,7 +45,7 @@ fun PermissionRequestDialog(
 private fun PermissionRequestDialogPreview() {
     TnTTheme {
         PermissionRequestDialog(
-            permission = TnTPermission.MEDIA_ACCESS,
+            permission = TnTPermission.NOTIFICATION,
             isPermanentlyDenied = false,
             onOkButtonClick = { },
             onDismissRequest = { },

--- a/core/ui/src/main/java/co/kr/tnt/ui/permission/TnTPermission.kt
+++ b/core/ui/src/main/java/co/kr/tnt/ui/permission/TnTPermission.kt
@@ -1,16 +1,11 @@
 package co.kr.tnt.ui.permission
 
 import android.Manifest.permission.POST_NOTIFICATIONS
-import android.Manifest.permission.READ_EXTERNAL_STORAGE
-import android.Manifest.permission.READ_MEDIA_IMAGES
-import android.Manifest.permission.READ_MEDIA_VIDEO
-import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
 import android.os.Build
 import androidx.annotation.StringRes
 import co.kr.tnt.core.ui.R
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
-import com.google.accompanist.permissions.isGranted
 
 enum class TnTPermission(
     val values: List<String>,
@@ -30,26 +25,6 @@ enum class TnTPermission(
         permanentlyDeniedTitle = R.string.alarm_permission_permanently_title,
         permanentlyDeniedDescription = R.string.alarm_permission_permanently_description,
     ),
-    MEDIA_ACCESS(
-        values = when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> listOf(
-                READ_MEDIA_IMAGES,
-                READ_MEDIA_VIDEO,
-                READ_MEDIA_VISUAL_USER_SELECTED,
-            )
-
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> listOf(
-                READ_MEDIA_IMAGES,
-                READ_MEDIA_VIDEO,
-            )
-
-            else -> listOf(READ_EXTERNAL_STORAGE)
-        },
-        title = R.string.media_permission_title,
-        description = R.string.media_permission_description,
-        permanentlyDeniedTitle = R.string.media_permission_permanently_title,
-        permanentlyDeniedDescription = R.string.media_permission_permanently_description,
-    ),
     ;
 
     /**
@@ -64,16 +39,6 @@ enum class TnTPermission(
     fun isRequireGranted(permissions: MultiplePermissionsState): Boolean {
         return when (this) {
             NOTIFICATION -> permissions.allPermissionsGranted
-            MEDIA_ACCESS -> {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    return permissions.allPermissionsGranted
-                }
-
-                return permissions.allPermissionsGranted ||
-                    permissions.permissions.any {
-                        it.permission == READ_MEDIA_VISUAL_USER_SELECTED && it.status.isGranted
-                    }
-            }
         }
     }
 }

--- a/domain/src/main/java/co/kr/tnt/domain/Constants.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/Constants.kt
@@ -1,0 +1,4 @@
+package co.kr.tnt.domain
+
+// TnT 에서 사용자가 업로드할 수 있는 이미지의 최대 용량은 10MB이다.
+const val IMAGE_MAX_SIZE = 10 * 1024 * 1024

--- a/feature/trainee/signup/build.gradle.kts
+++ b/feature/trainee/signup/build.gradle.kts
@@ -10,5 +10,4 @@ android {
 
 dependencies {
     implementation(libs.kotlinx.immutable)
-    implementation(libs.accompanist.permissions)
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
@@ -15,11 +15,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,24 +29,13 @@ import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
 import co.kr.tnt.feature.trainee.signup.R
 import co.kr.tnt.trainee.signup.component.ProgressSteps
-import co.kr.tnt.ui.extensions.moveToAppSetting
-import co.kr.tnt.ui.permission.PermissionRequestDialog
-import co.kr.tnt.ui.permission.TnTPermission
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
-@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun TraineeProfileSetupScreen() {
-    val context = LocalContext.current
-
     // TODO 상태 관리 따로 빼기
     val maxLength = 15
     var text by remember { mutableStateOf("") }
     val isWarning by remember { derivedStateOf { text.length > maxLength } }
-
-    var showPermissionRequestDialog by rememberSaveable { mutableStateOf(false) }
-    val mediaPermissions = rememberMultiplePermissionsState(TnTPermission.MEDIA_ACCESS.values)
 
     Scaffold(
         // TODO 버튼 클릭 시 트레이너/트레이니 화면으로 이동
@@ -71,13 +58,8 @@ fun TraineeProfileSetupScreen() {
                 TnTProfileImage(
                     modifier = Modifier.fillMaxWidth(),
                     type = ProfileType.Trainee,
-                    onEditClick = onEditClick@{
-                        if (TnTPermission.MEDIA_ACCESS.isRequireGranted(mediaPermissions)) {
-                            // TODO 이미지 피커 이동
-                            return@onEditClick
-                        }
-
-                        showPermissionRequestDialog = true
+                    onEditClick = {
+                        // TODO 이미지 피커 이동
                     },
                 )
                 Spacer(Modifier.padding(top = 60.dp))
@@ -103,26 +85,6 @@ fun TraineeProfileSetupScreen() {
                 enabled = text.isNotBlank() && !isWarning,
                 onClick = { },
                 modifier = Modifier.align(Alignment.BottomCenter),
-            )
-        }
-
-        if (showPermissionRequestDialog) {
-            PermissionRequestDialog(
-                permission = TnTPermission.MEDIA_ACCESS,
-                isPermanentlyDenied = mediaPermissions.shouldShowRationale,
-                onOkButtonClick = onOkButtonClick@{ isPermanentlyDenied ->
-                    showPermissionRequestDialog = false
-
-                    if (isPermanentlyDenied.not()) {
-                        mediaPermissions.launchMultiplePermissionRequest()
-                        return@onOkButtonClick
-                    }
-
-                    context.moveToAppSetting()
-                },
-                onDismissRequest = {
-                    showPermissionRequestDialog = false
-                },
             )
         }
     }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,12 +32,17 @@ import co.kr.tnt.designsystem.component.button.TnTBottomButton
 import co.kr.tnt.designsystem.component.image.TnTProfileImage
 import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
+import co.kr.tnt.domain.IMAGE_MAX_SIZE
 import co.kr.tnt.feature.trainee.signup.R
 import co.kr.tnt.trainee.signup.component.ProgressSteps
+import co.kr.tnt.ui.coil.ResizeTransformation
 import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 
 @Composable
 fun TraineeProfileSetupScreen() {
+    val context = LocalContext.current
+
     // TODO 상태 관리 따로 빼기
     val maxLength = 15
     var text by remember { mutableStateOf("") }
@@ -44,9 +50,16 @@ fun TraineeProfileSetupScreen() {
     var profileImage by remember { mutableStateOf<Uri?>(null) }
 
     val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
-        profileImage = uri
+        if (uri != null) {
+            profileImage = uri
+        }
     }
-    val painter = rememberAsyncImagePainter(profileImage)
+    val painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(context)
+            .data(profileImage)
+            .transformations(ResizeTransformation(IMAGE_MAX_SIZE))
+            .build(),
+    )
 
     Scaffold(
         // TODO 버튼 클릭 시 트레이너/트레이니 화면으로 이동

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupScreen.kt
@@ -1,5 +1,9 @@
 package co.kr.tnt.trainee.signup
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -29,6 +33,7 @@ import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
 import co.kr.tnt.feature.trainee.signup.R
 import co.kr.tnt.trainee.signup.component.ProgressSteps
+import coil.compose.rememberAsyncImagePainter
 
 @Composable
 fun TraineeProfileSetupScreen() {
@@ -36,6 +41,12 @@ fun TraineeProfileSetupScreen() {
     val maxLength = 15
     var text by remember { mutableStateOf("") }
     val isWarning by remember { derivedStateOf { text.length > maxLength } }
+    var profileImage by remember { mutableStateOf<Uri?>(null) }
+
+    val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
+        profileImage = uri
+    }
+    val painter = rememberAsyncImagePainter(profileImage)
 
     Scaffold(
         // TODO 버튼 클릭 시 트레이너/트레이니 화면으로 이동
@@ -57,9 +68,14 @@ fun TraineeProfileSetupScreen() {
                 Spacer(Modifier.padding(top = 48.dp))
                 TnTProfileImage(
                     modifier = Modifier.fillMaxWidth(),
+                    image = profileImage?.let { painter },
                     type = ProfileType.Trainee,
                     onEditClick = {
-                        // TODO 이미지 피커 이동
+                        pickMediaLauncher.launch(
+                            PickVisualMediaRequest(
+                                mediaType = PickVisualMedia.ImageOnly,
+                            ),
+                        )
                     },
                 )
                 Spacer(Modifier.padding(top = 60.dp))

--- a/feature/trainer/signup/build.gradle.kts
+++ b/feature/trainer/signup/build.gradle.kts
@@ -10,5 +10,4 @@ android {
 
 dependencies {
     implementation(libs.kotlinx.immutable)
-    implementation(libs.accompanist.permissions)
 }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
@@ -1,5 +1,9 @@
 package co.kr.tnt.trainer.signup
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -29,6 +33,7 @@ import co.kr.tnt.designsystem.component.image.TnTProfileImage
 import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
 import co.kr.tnt.feature.trainer.signup.R
+import coil.compose.rememberAsyncImagePainter
 
 @Composable
 fun TrainerProfileSetupScreen() {
@@ -36,6 +41,12 @@ fun TrainerProfileSetupScreen() {
     val maxLength = 15
     var text by remember { mutableStateOf("") }
     val isWarning by remember { derivedStateOf { text.length > maxLength } }
+    var profileImage by remember { mutableStateOf<Uri?>(null) }
+
+    val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
+        profileImage = uri
+    }
+    val painter = rememberAsyncImagePainter(profileImage)
 
     Scaffold(
         topBar = { TnTTopBar(onBackClick = {}) },
@@ -58,9 +69,14 @@ fun TrainerProfileSetupScreen() {
                 Spacer(Modifier.padding(top = 48.dp))
                 TnTProfileImage(
                     modifier = Modifier.fillMaxWidth(),
+                    image = profileImage?.let { painter },
                     type = ProfileType.Trainer,
                     onEditClick = {
-                        // TODO 이미지 피커 이동
+                        pickMediaLauncher.launch(
+                            PickVisualMediaRequest(
+                                mediaType = PickVisualMedia.ImageOnly,
+                            ),
+                        )
                     },
                 )
                 Spacer(Modifier.padding(top = 60.dp))

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
@@ -16,11 +16,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,24 +29,13 @@ import co.kr.tnt.designsystem.component.image.TnTProfileImage
 import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
 import co.kr.tnt.feature.trainer.signup.R
-import co.kr.tnt.ui.extensions.moveToAppSetting
-import co.kr.tnt.ui.permission.PermissionRequestDialog
-import co.kr.tnt.ui.permission.TnTPermission
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
-@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun TrainerProfileSetupScreen() {
-    val context = LocalContext.current
-
     // TODO 상태 관리 따로 빼기
     val maxLength = 15
     var text by remember { mutableStateOf("") }
     val isWarning by remember { derivedStateOf { text.length > maxLength } }
-
-    var showPermissionRequestDialog by rememberSaveable { mutableStateOf(false) }
-    val mediaPermissions = rememberMultiplePermissionsState(TnTPermission.MEDIA_ACCESS.values)
 
     Scaffold(
         topBar = { TnTTopBar(onBackClick = {}) },
@@ -72,13 +59,8 @@ fun TrainerProfileSetupScreen() {
                 TnTProfileImage(
                     modifier = Modifier.fillMaxWidth(),
                     type = ProfileType.Trainer,
-                    onEditClick = onEditClick@{
-                        if (TnTPermission.MEDIA_ACCESS.isRequireGranted(mediaPermissions)) {
-                            // TODO 이미지 피커 이동
-                            return@onEditClick
-                        }
-
-                        showPermissionRequestDialog = true
+                    onEditClick = {
+                        // TODO 이미지 피커 이동
                     },
                 )
                 Spacer(Modifier.padding(top = 60.dp))
@@ -104,26 +86,6 @@ fun TrainerProfileSetupScreen() {
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = text.isNotBlank() && !isWarning,
                 onClick = { },
-            )
-        }
-
-        if (showPermissionRequestDialog) {
-            PermissionRequestDialog(
-                permission = TnTPermission.MEDIA_ACCESS,
-                isPermanentlyDenied = mediaPermissions.shouldShowRationale,
-                onOkButtonClick = onOkButtonClick@{ isPermanentlyDenied ->
-                    showPermissionRequestDialog = false
-
-                    if (isPermanentlyDenied.not()) {
-                        mediaPermissions.launchMultiplePermissionRequest()
-                        return@onOkButtonClick
-                    }
-
-                    context.moveToAppSetting()
-                },
-                onDismissRequest = {
-                    showPermissionRequestDialog = false
-                },
             )
         }
     }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,11 +33,16 @@ import co.kr.tnt.designsystem.component.button.TnTBottomButton
 import co.kr.tnt.designsystem.component.image.TnTProfileImage
 import co.kr.tnt.designsystem.component.image.model.ProfileType
 import co.kr.tnt.designsystem.theme.TnTTheme
+import co.kr.tnt.domain.IMAGE_MAX_SIZE
 import co.kr.tnt.feature.trainer.signup.R
+import co.kr.tnt.ui.coil.ResizeTransformation
 import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 
 @Composable
 fun TrainerProfileSetupScreen() {
+    val context = LocalContext.current
+
     // TODO 상태 관리 따로 빼기
     val maxLength = 15
     var text by remember { mutableStateOf("") }
@@ -44,9 +50,16 @@ fun TrainerProfileSetupScreen() {
     var profileImage by remember { mutableStateOf<Uri?>(null) }
 
     val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
-        profileImage = uri
+        if (uri != null) {
+            profileImage = uri
+        }
     }
-    val painter = rememberAsyncImagePainter(profileImage)
+    val painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(context)
+            .data(profileImage)
+            .transformations(ResizeTransformation(IMAGE_MAX_SIZE))
+            .build(),
+    )
 
     Scaffold(
         topBar = { TnTTopBar(onBackClick = {}) },


### PR DESCRIPTION
## 📝 작업 내용

- Closes #20 

- 사용자가 이미지를 선택할 수 있도록 이미지 피커 (`Android Photo Picker`)를 구현하였습니다.

</br>

- 저장소 접근 권한에 따라 사용자가 접근 허용한 이미지만을 선택할 수 있도록 초기 구현을 구상하였으나, 이미지를 '선택만' 할 수 있어도 기획 요구사항이 충족되기 때문에 `Android Photo Picker` 를 사용하였습니다.

</br>

- 서버측 (@ymkim97) 과의 합의에 따라 이미지의 용량이 10MB를 넘어가지 않도록 구현하였습니다.
    - 만약 이미지 용량이 10MB를 넘을 경우, 자체적으로 리사이징을 진행합니다.


## 📸 실행 화면


https://github.com/user-attachments/assets/aeb69cb4-6e00-445d-9212-051dcb7fd16c

## 🙆🏻 리뷰 요청 사항

- NONE

## 👀 레퍼런스

- [Android Photo Picker](https://developer.android.com/training/data-storage/shared/photopicker)