### PR TITLE
[TNT-234] 트레이너 PT 세션 완료, 회원수 조회 API 연동

### DIFF
--- a/data/network/src/main/java/co/kr/data/network/model/UserResponse.kt
+++ b/data/network/src/main/java/co/kr/data/network/model/UserResponse.kt
@@ -2,6 +2,7 @@ package co.kr.data.network.model
 
 import co.kr.data.network.model.enum.MemberType
 import co.kr.tnt.domain.model.User
+import co.kr.tnt.domain.model.trainer.TrainerManagementMemberCount
 import co.kr.tnt.domain.utils.DateFormatter
 import kotlinx.serialization.Serializable
 
@@ -20,7 +21,6 @@ data class UserResponse(
 data class TrainerResponse(
     val activeTraineeCount: Int?,
     val totalTraineeCount: Int?,
-    val invitationCode: String?,
 )
 
 @Serializable
@@ -39,6 +39,10 @@ fun UserResponse.toDomain(dateFormatter: DateFormatter): User {
             id = "TODO",
             name = name,
             image = profileImageUrl,
+            memberCounts = TrainerManagementMemberCount(
+                activeCount = trainer?.activeTraineeCount ?: 0,
+                totalCount = trainer?.totalTraineeCount ?: 0,
+            ),
         )
 
         MemberType.TRAINEE -> User.Trainee(

--- a/data/network/src/main/java/co/kr/data/network/service/ApiService.kt
+++ b/data/network/src/main/java/co/kr/data/network/service/ApiService.kt
@@ -98,6 +98,11 @@ interface ApiService {
         @Body request: PtSessionRequest,
     )
 
+    @PUT("/trainers/lessons/{ptSessionId}/complete")
+    suspend fun putCompletePtSession(
+        @Path("ptSessionId") ptSessionId: String,
+    )
+
     // Trainee
     @Multipart
     @POST("/trainees/diets")

--- a/data/network/src/main/java/co/kr/data/network/source/TrainerRemoteDataSource.kt
+++ b/data/network/src/main/java/co/kr/data/network/source/TrainerRemoteDataSource.kt
@@ -36,4 +36,8 @@ class TrainerRemoteDataSource @Inject constructor(
     suspend fun postPtSession(request: PtSessionRequest) = networkHandler {
         apiService.postPtSession(request)
     }
+
+    suspend fun putCompletePtSession(ptSessionId: String) = networkHandler {
+        apiService.putCompletePtSession(ptSessionId)
+    }
 }

--- a/data/repository/src/main/java/co/kr/data/repository/TrainerRepositoryImpl.kt
+++ b/data/repository/src/main/java/co/kr/data/repository/TrainerRepositoryImpl.kt
@@ -62,4 +62,7 @@ internal class TrainerRepositoryImpl @Inject constructor(
             ),
         )
     }
+
+    override suspend fun postCompleteSession(ptSessionId: String) =
+        trainerRemoteDataSource.putCompletePtSession(ptSessionId)
 }

--- a/domain/src/main/java/co/kr/tnt/domain/model/User.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/model/User.kt
@@ -1,5 +1,6 @@
 package co.kr.tnt.domain.model
 
+import co.kr.tnt.domain.model.trainer.TrainerManagementMemberCount
 import java.time.LocalDate
 
 sealed class User {
@@ -7,16 +8,19 @@ sealed class User {
     abstract val name: String
     abstract val image: String?
 
+    // TODO [membersCount] 가 이 도메인 모델에 위치해 있는게 어색함.
     data class Trainer(
         override val id: String,
         override val name: String,
         override val image: String?,
+        val memberCounts: TrainerManagementMemberCount,
     ) : User() {
         companion object {
             val EMPTY = Trainer(
                 id = "",
                 name = "",
                 image = null,
+                memberCounts = TrainerManagementMemberCount.ZERO,
             )
         }
     }

--- a/domain/src/main/java/co/kr/tnt/domain/model/trainer/TrainerManagementMemberCount.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/model/trainer/TrainerManagementMemberCount.kt
@@ -2,12 +2,12 @@ package co.kr.tnt.domain.model.trainer
 
 data class TrainerManagementMemberCount(
     val activeCount: Int,
-    val cumulativeCount: Int,
+    val totalCount: Int,
 ) {
     companion object {
         val ZERO = TrainerManagementMemberCount(
             activeCount = 0,
-            cumulativeCount = 0,
+            totalCount = 0,
         )
     }
 }

--- a/domain/src/main/java/co/kr/tnt/domain/repository/TrainerRepository.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/repository/TrainerRepository.kt
@@ -19,4 +19,5 @@ interface TrainerRepository {
         memo: String,
         traineeId: Long,
     )
+    suspend fun postCompleteSession(ptSessionId: String)
 }

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectViewModel.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectViewModel.kt
@@ -2,6 +2,7 @@ package co.kr.tnt.trainer.connect
 
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.model.User
+import co.kr.tnt.domain.model.trainer.TrainerManagementMemberCount
 import co.kr.tnt.domain.repository.ConnectRepository
 import co.kr.tnt.trainer.connect.TrainerConnectContract.TrainerConnectPage
 import co.kr.tnt.trainer.connect.TrainerConnectContract.TrainerConnectSideEffect
@@ -44,6 +45,7 @@ internal class TrainerConnectViewModel @Inject constructor(
                             id = "",
                             name = result.trainerName,
                             image = result.trainerImage,
+                            memberCounts = TrainerManagementMemberCount.ZERO,
                         ),
                         traineeState = User.Trainee(
                             id = "",

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
@@ -20,6 +20,7 @@ internal class TrainerHomeContract {
         data class OnChangeVisibleMonth(val yearMonth: YearMonth) : TrainerHomeUiEvent
         data class OnClickDay(val day: LocalDate) : TrainerHomeUiEvent
         data object OnClickAddPtSession : TrainerHomeUiEvent
+        data class OnClickPtSessionComplete(val ptSession: PtSession) : TrainerHomeUiEvent
     }
 
     sealed interface TrainerHomeSideEffect : UiSideEffect {

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -1,5 +1,6 @@
 package co.kr.tnt.trainer.home
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -74,6 +75,7 @@ internal fun TrainerHomeRoute(
         onChangeVisibleMonth = { viewModel.setEvent(TrainerHomeUiEvent.OnChangeVisibleMonth(it)) },
         onClickDay = { viewModel.setEvent(TrainerHomeUiEvent.OnClickDay(it)) },
         onClickAddPtSession = { viewModel.setEvent(TrainerHomeUiEvent.OnClickAddPtSession) },
+        onClickPtSessionComplete = { viewModel.setEvent(TrainerHomeUiEvent.OnClickPtSessionComplete(it)) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -97,6 +99,7 @@ private fun TrainerHomeScreen(
     onChangeVisibleMonth: (yearMonth: YearMonth) -> Unit,
     onClickDay: (date: LocalDate) -> Unit,
     onClickAddPtSession: () -> Unit,
+    onClickPtSessionComplete: (PtSession) -> Unit,
 ) {
     val now = remember { YearMonth.now() }
     val calendarState = rememberCalendarState(
@@ -165,6 +168,7 @@ private fun TrainerHomeScreen(
                     PtSessionCard(
                         ptSession = selectDayPtSessions[index],
                         dateFormatter = dateFormatter,
+                        onClickComplete = onClickPtSessionComplete,
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -289,6 +293,7 @@ private fun PtSessionCard(
     ptSession: PtSession,
     dateFormatter: DateFormatter,
     modifier: Modifier = Modifier,
+    onClickComplete: (PtSession) -> Unit,
 ) {
     val painter = rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current)
@@ -299,13 +304,21 @@ private fun PtSessionCard(
     )
 
     Row(
-        modifier = modifier.padding(horizontal = 20.dp),
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .animateContentSize(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .clickable(onClick = { })
+                .then(
+                    if (ptSession.isCompleted.not()) {
+                        Modifier.clickable { onClickComplete(ptSession) }
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(4.dp),
             painter = painterResource(
                 if (ptSession.isCompleted) {
@@ -346,6 +359,7 @@ private fun TrainerHomeScreenPreview() {
             onChangeVisibleMonth = { },
             onClickDay = { },
             onClickAddPtSession = { },
+            onClickPtSessionComplete = { },
         )
     }
 }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -39,6 +39,7 @@ internal class TrainerHomeViewModel @Inject constructor(
                 is TrainerHomeUiEvent.OnChangeVisibleMonth -> handleChangeVisibleMonth(event.yearMonth)
                 is TrainerHomeUiEvent.OnClickDay -> selectDay(event.day)
                 TrainerHomeUiEvent.OnClickAddPtSession -> sendEffect(TrainerHomeSideEffect.NavigateToAddPtSession)
+                is TrainerHomeUiEvent.OnClickPtSessionComplete -> completePtSession(event.ptSession)
             }
         }
 
@@ -96,6 +97,33 @@ internal class TrainerHomeViewModel @Inject constructor(
             }
 
             updateState { copy(dailyPtSessionCount = updatedDailyPtSessionCount) }
+        }
+
+        private fun completePtSession(ptSession: PtSession) {
+            viewModelScope.launch {
+                runCatching {
+                    trainerRepository.postCompleteSession(ptSession.id)
+                }.onSuccess {
+                    getDailyPtSessions(currentState.selectedDay)
+                }.onFailure {
+                    sendEffect(TrainerHomeSideEffect.ShowToast("서버 요청에 실패했어요"))
+                }
+            }
+        }
+
+        private fun getDailyPtSessions(day: LocalDate) {
+            viewModelScope.launch {
+                runCatching {
+                    trainerRepository.getDailyPtSessions(day)
+                }.onSuccess {
+                    cachedDailyPtSession[day] = it.sessions
+                    if (day == currentState.selectedDay) {
+                        updateState { copy(selectedDayPtSessions = cachedDailyPtSession[day]) }
+                    }
+                }.onFailure {
+                    sendEffect(TrainerHomeSideEffect.ShowToast("서버 요청에 실패했어요"))
+                }
+            }
         }
 
         private fun refresh() {

--- a/feature/trainer/mypage/src/main/java/co/kr/tnt/trainer/mypage/TrainerMyPageContract.kt
+++ b/feature/trainer/mypage/src/main/java/co/kr/tnt/trainer/mypage/TrainerMyPageContract.kt
@@ -1,7 +1,6 @@
 package co.kr.tnt.trainer.mypage
 
 import co.kr.tnt.domain.model.User
-import co.kr.tnt.domain.model.trainer.TrainerManagementMemberCount
 import co.kr.tnt.ui.base.UiEvent
 import co.kr.tnt.ui.base.UiSideEffect
 import co.kr.tnt.ui.base.UiState
@@ -11,7 +10,6 @@ internal class TrainerMyPageContract {
         val user: User.Trainer = User.Trainer.EMPTY,
         val isEnablePushNotification: Boolean = true,
         val dialogState: DialogState = DialogState.NONE,
-        val managementMemberCount: TrainerManagementMemberCount = TrainerManagementMemberCount.ZERO,
     ) : UiState {
         enum class DialogState {
             NONE,

--- a/feature/trainer/mypage/src/main/java/co/kr/tnt/trainer/mypage/TrainerMyPageScreen.kt
+++ b/feature/trainer/mypage/src/main/java/co/kr/tnt/trainer/mypage/TrainerMyPageScreen.kt
@@ -164,12 +164,12 @@ private fun TrainerMyPageScreen(
         ) {
             ManagementMemberCount(
                 title = "관리 중인 회원",
-                count = state.managementMemberCount.activeCount,
+                count = state.user.memberCounts.activeCount,
             )
             Spacer(modifier = Modifier.width(8.dp))
             ManagementMemberCount(
                 title = "함께 했던 회원",
-                count = state.managementMemberCount.cumulativeCount,
+                count = state.user.memberCounts.totalCount,
             )
         }
         Spacer(Modifier.height(16.dp))
@@ -362,12 +362,12 @@ private fun TrainerMyPageScreenPreview() {
                     id = "1",
                     name = "김헬짱",
                     image = null,
+                    memberCounts = TrainerManagementMemberCount(
+                        activeCount = 23,
+                        totalCount = 26,
+                    ),
                 ),
                 isEnablePushNotification = false,
-                managementMemberCount = TrainerManagementMemberCount(
-                    activeCount = 23,
-                    cumulativeCount = 26,
-                ),
             ),
             appVersion = "1.0.0",
             onTogglePushNotification = { },

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.model.User
+import co.kr.tnt.domain.model.trainer.TrainerManagementMemberCount
 import co.kr.tnt.domain.repository.SignUpRepository
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpEffect
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpPage
@@ -66,6 +67,7 @@ internal class TrainerSignUpViewModel @Inject constructor(
                         id = id,
                         name = currentState.name,
                         image = currentState.image.toString(),
+                        memberCounts = TrainerManagementMemberCount.ZERO,
                     ),
                     socialId = id,
                     socialType = authType,


### PR DESCRIPTION
## 📝 작업 내용

- Closes #80 

</br>

- 트레이너 PT 세션 완료 API를 연동하였습니다.
- 트레이너 관리 회원 수를 출력하도록 수정하였습니다.


## 📸 실행 화면


https://github.com/user-attachments/assets/7772b953-f25d-4fc6-8c0d-3ef5c256a683



## 🙆🏻 리뷰 요청 사항

- NONE

## 👀 레퍼런스

- NONE
