### PR TITLE
[TNT-187] FCM 기본 세팅

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -21,6 +21,10 @@ jobs:
           echo DEBUG_BASE_API_URL=\"${{ secrets.DEBUG_BASE_API_URL }}\" >> ./local.properties
           echo KAKAO_NATIVE_APP_KEY=${{ secrets.KAKAO_NATIVE_APP_KEY }} >> ./local.properties
 
+      - name: add google-services.json
+        run: |
+          echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/src/google-services.json
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,android
+app/google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("tnt.android.application")
     id("tnt.android.compose")
     id("com.google.android.gms.oss-licenses-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -61,4 +62,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.kakao.user)
     implementation(libs.play.services.oss.licenses)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
+    implementation(libs.firebase.analytics)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,14 @@
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
+
+        <service
+            android:name=".service.MessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/co/kr/tnt/service/MessagingService.kt
+++ b/app/src/main/java/co/kr/tnt/service/MessagingService.kt
@@ -1,0 +1,19 @@
+package co.kr.tnt.service
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        // TODO
+    }
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        // TODO
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,4 +20,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/data/network/src/main/java/co/kr/data/network/model/LoginRequest.kt
+++ b/data/network/src/main/java/co/kr/data/network/model/LoginRequest.kt
@@ -3,10 +3,9 @@ package co.kr.data.network.model
 import co.kr.tnt.domain.model.AuthType
 import kotlinx.serialization.Serializable
 
-// TODO fcm token
 @Serializable
 data class LoginRequest(
     val socialType: AuthType,
-    val fcmToken: String = "EMPTY",
+    val fcmToken: String,
     val socialAccessToken: String,
 )

--- a/data/repository/src/main/java/co/kr/data/repository/LoginRepositoryImpl.kt
+++ b/data/repository/src/main/java/co/kr/data/repository/LoginRepositoryImpl.kt
@@ -22,11 +22,13 @@ internal class LoginRepositoryImpl @Inject constructor(
 
     override suspend fun login(
         authType: AuthType,
+        messagingToken: String,
         accessToken: String,
     ): LoginResult {
         val response = loginRemoteDataSource.postLogin(
             loginRequest = LoginRequest(
                 socialType = authType,
+                fcmToken = messagingToken,
                 socialAccessToken = accessToken,
             ),
         )

--- a/domain/src/main/java/co/kr/tnt/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/repository/LoginRepository.kt
@@ -9,6 +9,7 @@ interface LoginRepository {
 
     suspend fun login(
         authType: AuthType,
+        messagingToken: String,
         accessToken: String,
     ): LoginResult
 

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -10,4 +10,7 @@ android {
 
 dependencies {
     implementation(projects.core.login)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
 }

--- a/feature/login/src/main/java/co/kr/tnt/login/LoginContract.kt
+++ b/feature/login/src/main/java/co/kr/tnt/login/LoginContract.kt
@@ -29,6 +29,7 @@ internal class LoginContract {
         data class OnCheckTerm(val termState: TermState) : LoginUiEvent
         data class OnClickTermLink(val link: String) : LoginUiEvent
         data object OnClickNext : LoginUiEvent
+        data class OnGetMessagingTokenSucceed(val token: String) : LoginUiEvent
     }
 
     sealed interface LoginSideEffect : UiSideEffect {

--- a/feature/login/src/main/java/co/kr/tnt/login/LoginScreen.kt
+++ b/feature/login/src/main/java/co/kr/tnt/login/LoginScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +55,8 @@ import co.kr.tnt.login.LoginContract.LoginUiEvent
 import co.kr.tnt.login.LoginContract.LoginUiState
 import co.kr.tnt.login.kakao.KakaoLoginSdk
 import co.kr.tnt.login.model.TermState
+import com.google.firebase.Firebase
+import com.google.firebase.messaging.messaging
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -137,6 +140,12 @@ internal fun LoginRoute(
                     navigateToSignup(effect.loginResult)
                 }
             }
+        }
+    }
+
+    SideEffect {
+        Firebase.messaging.token.addOnCompleteListener {
+            viewModel.setEvent(LoginUiEvent.OnGetMessagingTokenSucceed(token = it.result ?: ""))
         }
     }
 }

--- a/feature/login/src/main/java/co/kr/tnt/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/co/kr/tnt/login/LoginViewModel.kt
@@ -20,6 +20,7 @@ internal class LoginViewModel @Inject constructor(
         LoginUiState(),
     ) {
     private var loginResult: LoginResult? = null
+    private var messagingToken: String = ""
 
     override suspend fun handleEvent(event: LoginUiEvent) {
         when (event) {
@@ -39,6 +40,7 @@ internal class LoginViewModel @Inject constructor(
             }
 
             LoginUiEvent.OnClickNext -> navigateToSignup()
+            is LoginUiEvent.OnGetMessagingTokenSucceed -> messagingToken = event.token
         }
     }
 
@@ -51,6 +53,7 @@ internal class LoginViewModel @Inject constructor(
                 loginRepository.login(
                     authType = authType,
                     accessToken = accessToken,
+                    messagingToken = messagingToken,
                 )
             }.onSuccess { loginResult ->
                 loginResult.userType?.let { userType ->

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.kotlinx.immutable)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.accompanist.permissions)
+    implementation(libs.firebase.messaging)
     androidTestImplementation(libs.hilt.android.testing)
     kspAndroidTest(libs.hilt.android.compiler)
 }

--- a/feature/main/src/main/java/co/kr/tnt/main/MainActivity.kt
+++ b/feature/main/src/main/java/co/kr/tnt/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package co.kr.tnt.main
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -18,6 +19,7 @@ import co.kr.tnt.main.ui.rememberTnTAppState
 import co.kr.tnt.ui.permission.TnTPermission
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -33,6 +35,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        getMessagingToken()
         splashScreen.setKeepOnScreenCondition { viewModel.uiState.value.showSplash }
 
         setContent {
@@ -50,6 +53,16 @@ class MainActivity : ComponentActivity() {
             }
 
             CheckPermissionEffect()
+
+            LaunchedEffect(viewModel.effect) {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        is MainContract.MainSideEffect.ShowToast -> {
+                            Toast.makeText(this@MainActivity, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -67,5 +80,20 @@ class MainActivity : ComponentActivity() {
                 viewModel.setEvent(MainUiEvent.OnNotificationPermissionRevoked)
             }
         }
+    }
+
+    // TODO API 변경 시 제거 예정 코드
+    private fun getMessagingToken() {
+        FirebaseMessaging
+            .getInstance()
+            .token
+            .addOnSuccessListener { token ->
+                token?.let {
+                    viewModel.setEvent(MainUiEvent.OnGetMessagingTokenSucceeded(token))
+                } ?: viewModel.setEvent(MainUiEvent.OnGetMessagingTokenFailed)
+            }
+            .addOnFailureListener {
+                viewModel.setEvent(MainUiEvent.OnGetMessagingTokenFailed)
+            }
     }
 }

--- a/feature/main/src/main/java/co/kr/tnt/main/MainContract.kt
+++ b/feature/main/src/main/java/co/kr/tnt/main/MainContract.kt
@@ -13,7 +13,11 @@ internal class MainContract {
 
     sealed class MainUiEvent : UiEvent {
         data object OnNotificationPermissionRevoked : MainUiEvent()
+        data class OnGetMessagingTokenSucceeded(val token: String) : MainUiEvent()
+        data object OnGetMessagingTokenFailed : MainUiEvent()
     }
 
-    data object MainSideEffect : UiSideEffect
+    sealed interface MainSideEffect : UiSideEffect {
+        data class ShowToast(val message: String) : MainSideEffect
+    }
 }

--- a/feature/main/src/main/java/co/kr/tnt/main/MainViewModel.kt
+++ b/feature/main/src/main/java/co/kr/tnt/main/MainViewModel.kt
@@ -19,15 +19,25 @@ internal class MainViewModel @Inject constructor(
     private val settingRepository: SettingRepository,
 ) :
     BaseViewModel<MainUiState, MainUiEvent, MainSideEffect>(MainUiState()) {
-        init {
-            viewModelScope.launch {
-                val startDestination = getStartDestination()
+        override suspend fun handleEvent(event: MainUiEvent) {
+            when (event) {
+                MainUiEvent.OnNotificationPermissionRevoked -> settingRepository.setEnablePushNotification(false)
+                is MainUiEvent.OnGetMessagingTokenSucceeded -> {
+                    viewModelScope.launch {
+                        val startDestination = getStartDestination()
 
-                updateState {
-                    copy(
-                        showSplash = false,
-                        startDestination = startDestination,
-                    )
+                        updateState {
+                            copy(
+                                showSplash = false,
+                                startDestination = startDestination,
+                            )
+                        }
+                    }
+                }
+
+                // TODO API 변경 시 제거 예정 코드
+                MainUiEvent.OnGetMessagingTokenFailed -> {
+                    sendEffect(MainSideEffect.ShowToast("네트워크 환경을 확인하신 후 앱을 재실행해주세요."))
                 }
             }
         }
@@ -46,11 +56,5 @@ internal class MainViewModel @Inject constructor(
                     Route.Login
                 },
             )
-        }
-
-        override suspend fun handleEvent(event: MainUiEvent) {
-            when (event) {
-                MainUiEvent.OnNotificationPermissionRevoked -> settingRepository.setEnablePushNotification(false)
-            }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,11 @@ coroutine = "1.9.0"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 
+## firebase
+googleServices = "4.4.2"
+firebaseBom = "33.9.0"
+crashlytics = "3.0.3"
+
 ## Test
 junit = "4.13.2"
 junitJupiter = "5.11.4"
@@ -129,6 +134,10 @@ detekt-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 ktlint-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
 
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -140,3 +149,5 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }


### PR DESCRIPTION
## 📝 작업 내용

- Closes #50 

</br>

- FCM 기본 세팅을 구현하였습니다.
- 앱 최초 다운로드 후 파이어베이스 메시지 토큰을 불러오지 못한 경우, 스플래시 화면을 빠져나가지 못하도록 구현하였습니다.
   - 일단 임시 로직으로, 추후 API 변경 시 변경 예정입니다.


## 📸 실행 화면


https://github.com/user-attachments/assets/6c198538-85d3-4d0f-99b1-2e375da4b5cd




## 🙆🏻 리뷰 요청 사항

- **노션에 `google-services.json` 파일 넣어두었습니다! `app/src` 에 저장해주세요 !!!**


## 👀 레퍼런스

- [FCM 등록 토큰 관리를 위한 권장사항](https://firebase.google.com/docs/cloud-messaging/manage-tokens?hl=ko)