### PR TITLE
[TNT-241] 트레이너 연결 촉구 팝업 출력

### DIFF
--- a/data/repository/src/main/java/co/kr/data/repository/ConnectRepositoryImpl.kt
+++ b/data/repository/src/main/java/co/kr/data/repository/ConnectRepositoryImpl.kt
@@ -67,7 +67,7 @@ internal class ConnectRepositoryImpl @Inject constructor(
         return response.toDomain()
     }
 
-    override suspend fun getHomeDialogHiddenDate(): Flow<LocalDateTime?> =
+    override suspend fun getExplicitDeniedConnectDate(): Flow<LocalDateTime?> =
         connectLocalDataSource.explicitDeniedConnectDate.map { dateString ->
             dateString?.let {
                 runCatching { dateFormatter.parseDateTime(it) }
@@ -75,7 +75,7 @@ internal class ConnectRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun updateHomeDialogHiddenDate(date: LocalDateTime) {
+    override suspend fun updateExplicitDeniedConnectDate(date: LocalDateTime) {
         val formattedDate = dateFormatter.format(date)
         connectLocalDataSource.updateExplicitDeniedConnectDate(formattedDate)
     }

--- a/domain/src/main/java/co/kr/tnt/domain/repository/ConnectRepository.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/repository/ConnectRepository.kt
@@ -25,7 +25,7 @@ interface ConnectRepository {
         traineeId: String,
     ): ConnectedResult
 
-    suspend fun getHomeDialogHiddenDate(): Flow<LocalDateTime?>
+    suspend fun getExplicitDeniedConnectDate(): Flow<LocalDateTime?>
 
-    suspend fun updateHomeDialogHiddenDate(date: LocalDateTime)
+    suspend fun updateExplicitDeniedConnectDate(date: LocalDateTime)
 }

--- a/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeViewModel.kt
+++ b/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeViewModel.kt
@@ -143,7 +143,7 @@ internal class TraineeHomeViewModel @Inject constructor(
     private fun updateCurrentDateTime() {
         val currentDateTime = LocalDateTime.now()
         viewModelScope.launch {
-            connectRepository.updateHomeDialogHiddenDate(currentDateTime)
+            connectRepository.updateExplicitDeniedConnectDate(currentDateTime)
         }
     }
 
@@ -169,7 +169,7 @@ internal class TraineeHomeViewModel @Inject constructor(
                 sendEffect(TraineeHomeEffect.ShowToast("서버 요청에 실패했어요."))
             }
 
-            val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
+            val lastHiddenDate = connectRepository.getExplicitDeniedConnectDate().firstOrNull()
             val isHidden = lastHiddenDate != null &&
                 Duration.between(lastHiddenDate, currentDateTime).toHours() < DIALOG_HIDE_DURATION_HOURS
 

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
@@ -12,7 +12,15 @@ internal class TrainerHomeContract {
         val selectedDay: LocalDate = LocalDate.now(),
         val dailyPtSessionCount: Map<LocalDate, Int> = mapOf(),
         val selectedDayPtSessions: List<PtSession>? = null,
-    ) : UiState
+        val dialogState: DialogState = DialogState.NONE,
+        val isDialogHiddenForThreeDays: Boolean = false,
+    ) : UiState {
+        enum class DialogState {
+            NONE,
+            HOME_CONNECT,
+            ADD_PT_CONNECT,
+        }
+    }
 
     sealed interface TrainerHomeUiEvent : UiEvent {
         data object OnScreen : TrainerHomeUiEvent
@@ -21,11 +29,15 @@ internal class TrainerHomeContract {
         data class OnClickDay(val day: LocalDate) : TrainerHomeUiEvent
         data object OnClickAddPtSession : TrainerHomeUiEvent
         data class OnClickPtSessionComplete(val ptSession: PtSession) : TrainerHomeUiEvent
+        data object OnConfirmConnectDialog : TrainerHomeUiEvent
+        data object OnChangeHideDialogOption : TrainerHomeUiEvent
+        data object OnDismissDialog : TrainerHomeUiEvent
     }
 
     sealed interface TrainerHomeSideEffect : UiSideEffect {
         data object NavigateToNotification : TrainerHomeSideEffect
         data object NavigateToAddPtSession : TrainerHomeSideEffect
+        data object NavigateToConnect : TrainerHomeSideEffect
         data class ShowToast(val message: String) : TrainerHomeSideEffect
     }
 }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
@@ -37,7 +37,7 @@ internal class TrainerHomeContract {
     sealed interface TrainerHomeSideEffect : UiSideEffect {
         data object NavigateToNotification : TrainerHomeSideEffect
         data object NavigateToAddPtSession : TrainerHomeSideEffect
-        data object NavigateToConnect : TrainerHomeSideEffect
+        data object NavigateToInvite : TrainerHomeSideEffect
         data class ShowToast(val message: String) : TrainerHomeSideEffect
     }
 }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -71,6 +71,7 @@ internal fun TrainerHomeRoute(
     padding: PaddingValues,
     navigateToNotification: () -> Unit,
     navigateToAddPtSession: () -> Unit,
+    navigateToInvite: (Boolean) -> Unit,
 ) {
     val toast = LocalSnackbar.current
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -90,7 +91,7 @@ internal fun TrainerHomeRoute(
             when (effect) {
                 TrainerHomeSideEffect.NavigateToNotification -> navigateToNotification()
                 TrainerHomeSideEffect.NavigateToAddPtSession -> navigateToAddPtSession()
-                TrainerHomeSideEffect.NavigateToConnect -> TODO()
+                TrainerHomeSideEffect.NavigateToInvite -> navigateToInvite(false)
                 is TrainerHomeSideEffect.ShowToast -> toast.show(effect.message)
             }
         }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -38,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.kr.tnt.core.designsystem.R
+import co.kr.tnt.designsystem.component.TnTPopupDialog
 import co.kr.tnt.designsystem.component.button.TnTFabButton
 import co.kr.tnt.designsystem.component.calendar.TnTIndicatorMonthCalendar
 import co.kr.tnt.designsystem.component.calendar.model.DayIndicatorState
@@ -51,6 +53,7 @@ import co.kr.tnt.domain.utils.DateFormatter
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeSideEffect
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiEvent
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState
+import co.kr.tnt.ui.component.TnTCheckToggleDialog
 import co.kr.tnt.ui.component.TnTHomeTopBar
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
@@ -60,6 +63,7 @@ import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import co.kr.tnt.core.ui.R as coreR
 
 @Composable
 internal fun TrainerHomeRoute(
@@ -86,8 +90,39 @@ internal fun TrainerHomeRoute(
             when (effect) {
                 TrainerHomeSideEffect.NavigateToNotification -> navigateToNotification()
                 TrainerHomeSideEffect.NavigateToAddPtSession -> navigateToAddPtSession()
+                TrainerHomeSideEffect.NavigateToConnect -> TODO()
                 is TrainerHomeSideEffect.ShowToast -> toast.show(effect.message)
             }
+        }
+    }
+
+    when (state.dialogState) {
+        TrainerHomeUiState.DialogState.NONE -> Unit
+        TrainerHomeUiState.DialogState.HOME_CONNECT -> {
+            TnTCheckToggleDialog(
+                title = "회원을 연결해 주세요",
+                content = "연결하지 않을 경우 수업을 추가할 수 없어요\n초대 코드를 복사해 연결해주시겠어요?",
+                isChecked = state.isDialogHiddenForThreeDays,
+                checkToggleText = stringResource(coreR.string.do_not_see_for_three_days),
+                leftButtonText = stringResource(coreR.string.next_time),
+                rightButtonText = stringResource(coreR.string.connect),
+                onLeftButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+                onRightButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnConfirmConnectDialog) },
+                onCheckClick = { viewModel.setEvent(TrainerHomeUiEvent.OnChangeHideDialogOption) },
+                onDismiss = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+            )
+        }
+
+        TrainerHomeUiState.DialogState.ADD_PT_CONNECT -> {
+            TnTPopupDialog(
+                title = "회원을 연결해 주세요",
+                content = "연결하지 않을 경우 수업을 추가할 수 없어요\n초대 코드를 복사해 연결해주시겠어요?",
+                leftButtonText = stringResource(coreR.string.next_time),
+                rightButtonText = stringResource(coreR.string.connect),
+                onLeftButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+                onRightButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnConfirmConnectDialog) },
+                onDismiss = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+            )
         }
     }
 

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -24,6 +24,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 import javax.inject.Inject
 
+const val DIALOG_HIDE_DURATION_HOURS = 72
+
 @HiltViewModel
 internal class TrainerHomeViewModel @Inject constructor(
     private val trainerRepository: TrainerRepository,
@@ -161,7 +163,7 @@ internal class TrainerHomeViewModel @Inject constructor(
 
                 val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
                 val isHidden = lastHiddenDate != null &&
-                    Duration.between(lastHiddenDate, currentDateTime).toHours() < 72
+                    Duration.between(lastHiddenDate, currentDateTime).toHours() < DIALOG_HIDE_DURATION_HOURS
 
                 if (isHidden.not() && triggeredByHome) {
                     updateState { copy(dialogState = DialogState.HOME_CONNECT) }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -153,13 +153,14 @@ internal class TrainerHomeViewModel @Inject constructor(
                     if (result.isNotEmpty()) {
                         updateState { copy(dialogState = DialogState.NONE) }
                         if (triggeredByHome.not()) {
-                            sendEffect(TrainerHomeSideEffect.NavigateToConnect)
+                            sendEffect(TrainerHomeSideEffect.NavigateToInvite)
                         }
                         return@launch
                     }
                 }
 
                 val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
+                // TODO : 72시간으로 바꾸기
                 val isHidden = lastHiddenDate != null &&
                     Duration.between(lastHiddenDate, currentDateTime).toSeconds() < 5
 
@@ -180,8 +181,8 @@ internal class TrainerHomeViewModel @Inject constructor(
                 updateCurrentDateTime()
             }
             val effect = when (currentState.dialogState) {
-                DialogState.HOME_CONNECT -> TrainerHomeSideEffect.NavigateToConnect
-                DialogState.ADD_PT_CONNECT -> TrainerHomeSideEffect.NavigateToAddPtSession
+                DialogState.HOME_CONNECT -> TrainerHomeSideEffect.NavigateToInvite
+                DialogState.ADD_PT_CONNECT -> TrainerHomeSideEffect.NavigateToInvite
                 else -> return
             }
             updateState {

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -161,7 +161,7 @@ internal class TrainerHomeViewModel @Inject constructor(
                     }
                 }
 
-                val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
+                val lastHiddenDate = connectRepository.getExplicitDeniedConnectDate().firstOrNull()
                 val isHidden = lastHiddenDate != null &&
                     Duration.between(lastHiddenDate, currentDateTime).toHours() < DIALOG_HIDE_DURATION_HOURS
 
@@ -195,7 +195,7 @@ internal class TrainerHomeViewModel @Inject constructor(
         private fun updateCurrentDateTime() {
             val currentDateTime = LocalDateTime.now()
             viewModelScope.launch {
-                connectRepository.updateHomeDialogHiddenDate(currentDateTime)
+                connectRepository.updateExplicitDeniedConnectDate(currentDateTime)
             }
         }
 

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -3,17 +3,22 @@ package co.kr.tnt.trainer.home
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.model.PtSession
 import co.kr.tnt.domain.model.trainer.TrainerDailyPtSessionCount
+import co.kr.tnt.domain.repository.ConnectRepository
 import co.kr.tnt.domain.repository.TrainerRepository
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeSideEffect
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiEvent
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState
+import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState.DialogState
 import co.kr.tnt.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -22,6 +27,7 @@ import javax.inject.Inject
 @HiltViewModel
 internal class TrainerHomeViewModel @Inject constructor(
     private val trainerRepository: TrainerRepository,
+    private val connectRepository: ConnectRepository,
 ) :
     BaseViewModel<TrainerHomeUiState, TrainerHomeUiEvent, TrainerHomeSideEffect>(TrainerHomeUiState()) {
         private val cachedMonthlyPtSessionCounts: ConcurrentMap<YearMonth, List<TrainerDailyPtSessionCount>> =
@@ -38,8 +44,12 @@ internal class TrainerHomeViewModel @Inject constructor(
                 TrainerHomeUiEvent.OnClickNotification -> sendEffect(TrainerHomeSideEffect.NavigateToNotification)
                 is TrainerHomeUiEvent.OnChangeVisibleMonth -> handleChangeVisibleMonth(event.yearMonth)
                 is TrainerHomeUiEvent.OnClickDay -> selectDay(event.day)
-                TrainerHomeUiEvent.OnClickAddPtSession -> sendEffect(TrainerHomeSideEffect.NavigateToAddPtSession)
+                TrainerHomeUiEvent.OnClickAddPtSession -> showConnectDialog(false)
+
                 is TrainerHomeUiEvent.OnClickPtSessionComplete -> completePtSession(event.ptSession)
+                TrainerHomeUiEvent.OnChangeHideDialogOption -> toggleDialogHiddenState()
+                TrainerHomeUiEvent.OnConfirmConnectDialog -> handleDialogConfirm()
+                TrainerHomeUiEvent.OnDismissDialog -> dismissDialog()
             }
         }
 
@@ -130,5 +140,72 @@ internal class TrainerHomeViewModel @Inject constructor(
             cachedMonthlyPtSessionCounts.clear()
             cachedDailyPtSession.clear()
             selectDay(currentState.selectedDay)
+            showConnectDialog(true)
+        }
+
+        private fun showConnectDialog(triggeredByHome: Boolean) {
+            val currentDateTime = LocalDateTime.now()
+
+            viewModelScope.launch {
+                runCatching {
+                    trainerRepository.getActiveMembers()
+                }.onSuccess { result ->
+                    if (result.isNotEmpty()) {
+                        updateState { copy(dialogState = DialogState.NONE) }
+                        if (triggeredByHome.not()) {
+                            sendEffect(TrainerHomeSideEffect.NavigateToConnect)
+                        }
+                        return@launch
+                    }
+                }
+
+                val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
+                val isHidden = lastHiddenDate != null &&
+                    Duration.between(lastHiddenDate, currentDateTime).toSeconds() < 5
+
+                if (isHidden.not() && triggeredByHome) {
+                    updateState { copy(dialogState = DialogState.HOME_CONNECT) }
+                } else if (triggeredByHome.not()) {
+                    updateState { copy(dialogState = DialogState.ADD_PT_CONNECT) }
+                }
+            }
+        }
+
+        private fun toggleDialogHiddenState() {
+            updateState { copy(isDialogHiddenForThreeDays = !isDialogHiddenForThreeDays) }
+        }
+
+        private fun handleDialogConfirm() {
+            if (currentState.isDialogHiddenForThreeDays) {
+                updateCurrentDateTime()
+            }
+            val effect = when (currentState.dialogState) {
+                DialogState.HOME_CONNECT -> TrainerHomeSideEffect.NavigateToConnect
+                DialogState.ADD_PT_CONNECT -> TrainerHomeSideEffect.NavigateToAddPtSession
+                else -> return
+            }
+            updateState {
+                copy(dialogState = DialogState.NONE, isDialogHiddenForThreeDays = false)
+            }
+            sendEffect(effect)
+        }
+
+        private fun updateCurrentDateTime() {
+            val currentDateTime = LocalDateTime.now()
+            viewModelScope.launch {
+                connectRepository.updateHomeDialogHiddenDate(currentDateTime)
+            }
+        }
+
+        private fun dismissDialog() {
+            if (currentState.isDialogHiddenForThreeDays) {
+                updateCurrentDateTime()
+            }
+            updateState {
+                copy(
+                    dialogState = DialogState.NONE,
+                    isDialogHiddenForThreeDays = false,
+                )
+            }
         }
     }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -153,16 +153,15 @@ internal class TrainerHomeViewModel @Inject constructor(
                     if (result.isNotEmpty()) {
                         updateState { copy(dialogState = DialogState.NONE) }
                         if (triggeredByHome.not()) {
-                            sendEffect(TrainerHomeSideEffect.NavigateToInvite)
+                            sendEffect(TrainerHomeSideEffect.NavigateToAddPtSession)
                         }
                         return@launch
                     }
                 }
 
                 val lastHiddenDate = connectRepository.getHomeDialogHiddenDate().firstOrNull()
-                // TODO : 72시간으로 바꾸기
                 val isHidden = lastHiddenDate != null &&
-                    Duration.between(lastHiddenDate, currentDateTime).toSeconds() < 5
+                    Duration.between(lastHiddenDate, currentDateTime).toHours() < 72
 
                 if (isHidden.not() && triggeredByHome) {
                     updateState { copy(dialogState = DialogState.HOME_CONNECT) }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/navigation/TrainerHomeNavigation.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/navigation/TrainerHomeNavigation.kt
@@ -27,6 +27,7 @@ fun NavGraphBuilder.trainerHomeNavGraph(
     padding: PaddingValues,
     navigateToNotification: () -> Unit,
     navigateToAddPtSession: () -> Unit,
+    navigateToInvite: (Boolean) -> Unit,
     homeDestination: NavGraphBuilder.() -> Unit = { },
 ) {
     navigation<Route.TrainerMainTab.Home>(startDestination = Route.TrainerHome) {
@@ -35,6 +36,7 @@ fun NavGraphBuilder.trainerHomeNavGraph(
                 padding = padding,
                 navigateToNotification = navigateToNotification,
                 navigateToAddPtSession = navigateToAddPtSession,
+                navigateToInvite = navigateToInvite,
             )
         }
         homeDestination()

--- a/feature/trainer/main/src/main/java/co/kr/tnt/trainer/main/TrainerMainScreen.kt
+++ b/feature/trainer/main/src/main/java/co/kr/tnt/trainer/main/TrainerMainScreen.kt
@@ -69,6 +69,7 @@ private fun TrainerMainScreen(
                 padding = innerPadding,
                 navigateToNotification = navController::navigateToTrainerNotification,
                 navigateToAddPtSession = navController::navigateToAddPtSession,
+                navigateToInvite = navigateToInvite,
             ) {
                 trainerNotification(
                     navigateToPrevious = navController::popBackStack,


### PR DESCRIPTION
## 📝 작업 내용

- Closes #86 

- 홈 화면 진입 시 연결 요청 팝업이 자동으로 표시되도록 구현했습니다.
    - 관리중인 회원 목록 요청 API를 호출하여 `emptyList`인지 확인하고,
`회원이 없는 상태`이고 `3일 동안 보지 않기`로 설정한 시간이 지났다면
다이얼로그를 표시하도록 처리했습니다.

- 수업 추가 예외 처리 팝업을 구현했습니다.
    - 연결된 회원이 없을 때 수업 추가 버튼을 누르면 다이얼로그가 뜨고, `초대코드 확인 화면`으로 이동 가능합니다.
    - 회원이 있는 상태에서는 해당 팝업이 노출되지 않습니다.


## 📸 실행 화면
### 연결 팝업 임의로 5초간 보지 않도록 설정하여 테스트
https://github.com/user-attachments/assets/faf42dd3-a336-4d4d-8a8a-fbff82e2c4af

### 회원이 연결됐을 때 홈 화면
https://github.com/user-attachments/assets/95cc9cfe-08a3-4492-a54f-14c52ed115be

### 연결된 회원이 있을 때 수업 추가 버튼
https://github.com/user-attachments/assets/3713e949-9f5c-4fb4-8cd4-9b100287e2d3





## 🙆🏻 리뷰 요청 사항



## 👀 레퍼런스

