### PR TITLE
[TNT-000] QA 반영

### DIFF
--- a/core/designsystem/src/main/java/co/kr/tnt/designsystem/component/bottombar/BottomBar.kt
+++ b/core/designsystem/src/main/java/co/kr/tnt/designsystem/component/bottombar/BottomBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
@@ -39,7 +40,11 @@ fun <Tab : BottomTab> TnTBottomBar(
         enter = fadeIn(animationSpec = tween(700)) + slideIn { IntOffset(0, it.height) },
         exit = fadeOut(animationSpec = tween(700)) + slideOut { IntOffset(0, it.height) },
     ) {
-        Row(modifier = modifier.background(TnTTheme.colors.commonColors.Common0)) {
+        Row(
+            modifier = modifier
+                .shadow(elevation = 10.dp)
+                .background(TnTTheme.colors.commonColors.Common0),
+        ) {
             bottomTabs.forEach { tab ->
                 Button(
                     onClick = { onClickTab(tab) },

--- a/core/navigation/src/main/java/co/kr/tnt/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/co/kr/tnt/navigation/RouteModel.kt
@@ -103,7 +103,7 @@ sealed interface Route {
     data object TrainerNotification : Route
 
     @Serializable
-    data object AddPtSession : Route
+    data class AddPtSession(val selectedDate: String) : Route
 
     @Serializable
     data class TraineeMealRecord(val selectedDate: String) : Route

--- a/feature/main/src/main/java/co/kr/tnt/main/MainActivity.kt
+++ b/feature/main/src/main/java/co/kr/tnt/main/MainActivity.kt
@@ -1,5 +1,7 @@
 package co.kr.tnt.main
 
+import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -30,9 +32,12 @@ class MainActivity : ComponentActivity() {
 
     private val viewModel: MainViewModel by viewModels()
 
+    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
+
         enableEdgeToEdge()
 
         getMessagingToken()

--- a/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionScreen.kt
+++ b/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionScreen.kt
@@ -6,7 +6,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,16 +65,26 @@ fun RoleSelectionScreen(
     var selectedRole by remember { mutableStateOf(RoleState.fromDomain(UserType.TRAINER)) }
 
     Scaffold(
+        bottomBar = {
+            TnTBottomButton(
+                text = stringResource(uiResource.string.next),
+                enabled = true,
+                onClick = { onNextClick(selectedRole) },
+                modifier = Modifier.navigationBarsPadding(),
+            )
+        },
         modifier = Modifier.fillMaxSize(),
         containerColor = TnTTheme.colors.commonColors.Common0,
     ) { innerPadding ->
         Column(
+            verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            verticalArrangement = Arrangement.SpaceBetween,
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
         ) {
-            Column(modifier = Modifier.padding(start = 24.dp, top = 60.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                Spacer(Modifier.height(60.dp))
                 Text(
                     text = stringResource(R.string.select_role),
                     color = TnTTheme.colors.neutralColors.Neutral950,
@@ -113,11 +127,7 @@ fun RoleSelectionScreen(
                     },
                 )
             }
-            TnTBottomButton(
-                text = stringResource(uiResource.string.next),
-                enabled = true,
-                onClick = { onNextClick(selectedRole) },
-            )
+            Spacer(Modifier.height(60.dp))
         }
     }
 }

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/record/TraineeMealRecordContract.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/record/TraineeMealRecordContract.kt
@@ -36,7 +36,8 @@ internal class TraineeMealRecordContract {
             return copy(
                 isMealRecordValid = selectedDateTime != null && selectedDateTime <= now &&
                     mealType.isNotBlank() &&
-                    memo.isNotBlank(),
+                    memo.isNotBlank() &&
+                    memo.length < 100,
             )
         }
     }

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/record/TraineeMealRecordScreen.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/record/TraineeMealRecordScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -249,6 +250,7 @@ private fun TraineeMealRecordScreen(
             Column(
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(rememberScrollState()),
             ) {

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeBasicInfoPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeBasicInfoPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -63,6 +64,7 @@ internal fun TraineeBasicInfoPage(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(rememberScrollState()),
             ) {

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeNoteForTrainerPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeNoteForTrainerPage.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -45,6 +46,7 @@ internal fun TraineeNoteForTrainerPage(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(rememberScrollState()),
             ) {

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupPage.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -73,6 +74,7 @@ internal fun TraineeProfileSetupPage(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(rememberScrollState()),
             ) {

--- a/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/AddPtSessionScreen.kt
+++ b/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/AddPtSessionScreen.kt
@@ -86,6 +86,7 @@ import co.kr.tnt.core.ui.R as coreR
 
 @Composable
 internal fun AddPtSessionRoute(
+    selectedDate: String,
     viewModel: AddPtSessionViewModel = hiltViewModel(),
     navigateToPrevious: () -> Unit,
 ) {
@@ -93,8 +94,13 @@ internal fun AddPtSessionRoute(
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
+    val dateFormatter = remember { DateFormatter() }
 
     BackHandler { viewModel.setEvent(AddPtSessionUiEvent.OnClickBack) }
+
+    LaunchedEffect(selectedDate) {
+        viewModel.setEvent(AddPtSessionUiEvent.OnSelectDate(dateFormatter.parse(selectedDate)))
+    }
 
     AddPtSessionScreen(
         state = state,

--- a/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/AddPtSessionScreen.kt
+++ b/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/AddPtSessionScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -222,6 +223,7 @@ private fun AddPtSessionScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(state = rememberScrollState()),
             ) {

--- a/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/navigation/AddPtSessionNavigation.kt
+++ b/feature/trainer/addptsession/src/main/java/co/kr/tnt/trainer/addptsession/navigation/AddPtSessionNavigation.kt
@@ -4,20 +4,27 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import co.kr.tnt.navigation.Route
 import co.kr.tnt.trainer.addptsession.AddPtSessionRoute
 
 fun NavController.navigateToAddPtSession(
+    selectedDate: String,
     navOptions: NavOptionsBuilder.() -> Unit = {},
 ) = navigate(
-    route = Route.AddPtSession,
+    route = Route.AddPtSession(selectedDate),
     builder = navOptions,
 )
 
 fun NavGraphBuilder.addPtSession(
     navigateToPrevious: () -> Unit,
 ) {
-    composable<Route.AddPtSession> {
-        AddPtSessionRoute(navigateToPrevious = navigateToPrevious)
+    composable<Route.AddPtSession> { backstackEntry ->
+        backstackEntry.toRoute<Route.AddPtSession>().apply {
+            AddPtSessionRoute(
+                selectedDate = selectedDate,
+                navigateToPrevious = navigateToPrevious,
+            )
+        }
     }
 }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -72,7 +72,7 @@ internal fun TrainerHomeRoute(
     viewModel: TrainerHomeViewModel = hiltViewModel(),
     padding: PaddingValues,
     navigateToNotification: () -> Unit,
-    navigateToAddPtSession: () -> Unit,
+    navigateToAddPtSession: (selectedDate: String) -> Unit,
     navigateToInvite: (ScreenMode) -> Unit,
 ) {
     val toast = LocalSnackbar.current
@@ -92,7 +92,7 @@ internal fun TrainerHomeRoute(
         viewModel.effect.collect { effect ->
             when (effect) {
                 TrainerHomeSideEffect.NavigateToNotification -> navigateToNotification()
-                TrainerHomeSideEffect.NavigateToAddPtSession -> navigateToAddPtSession()
+                TrainerHomeSideEffect.NavigateToAddPtSession -> navigateToAddPtSession(state.selectedDay.toString())
                 TrainerHomeSideEffect.NavigateToInvite -> navigateToInvite(ScreenMode.CLOSE)
                 is TrainerHomeSideEffect.ShowToast -> toast.show(effect.message)
             }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/navigation/TrainerHomeNavigation.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/navigation/TrainerHomeNavigation.kt
@@ -27,7 +27,7 @@ fun NavController.navigateToTrainerHome(
 fun NavGraphBuilder.trainerHomeNavGraph(
     padding: PaddingValues,
     navigateToNotification: () -> Unit,
-    navigateToAddPtSession: () -> Unit,
+    navigateToAddPtSession: (selectedDate: String) -> Unit,
     navigateToInvite: (ScreenMode) -> Unit,
     homeDestination: NavGraphBuilder.() -> Unit = { },
 ) {

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupPage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupPage.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -74,6 +75,7 @@ internal fun TrainerProfileSetupPage(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(innerPadding)
                     .imePadding()
                     .verticalScroll(rememberScrollState()),
             ) {


### PR DESCRIPTION
## 📝 작업 내용

- 바텀 네비게이션 상단에 그림자 효과 추가
- PT 수업 추가 화면 이동 시, 홈 화면에서 선택되었던 날짜가 기본값으로 설정되도록 수정
- 앱 화면을 세로 모드로 고정하여 가로 회전 방지
- 식단 기록 메모 100자 제한 저장 버튼 활성화 조건에 반영
- 키보드 활성화 시 상단 여백 제거
- 역할 선택 화면 텍스트 크기 유동적으로 대응


## 📸 실행 화면




## 🙆🏻 리뷰 요청 사항



## 👀 레퍼런스

