### PR TITLE
[TNT-272][TNT-275] ViewModel 내 Context 제거 및 약관 링크 수정

### DIFF
--- a/domain/src/main/java/co/kr/tnt/domain/utils/AppUrls.kt
+++ b/domain/src/main/java/co/kr/tnt/domain/utils/AppUrls.kt
@@ -1,7 +1,6 @@
 package co.kr.tnt.domain.utils
 
 object AppUrls {
-    // TODO
-    const val PRIVACY_POLICY_URL = "https://fluffy-router-d0b.notion.site/775bc037dd1b4e8ba56679e51a7321e5"
-    const val TERMS_OF_SERVICE_URL = "https://fluffy-router-d0b.notion.site/f1ee7a43b6d941068723163fda127699"
+    const val PRIVACY_POLICY_URL = "https://ymkim97.notion.site/1bcd727836a3813e9f5dd60ed9620612"
+    const val TERMS_OF_SERVICE_URL = "https://ymkim97.notion.site/1bcd727836a381c08c7bdf4d70c3639b"
 }

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordContract.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordContract.kt
@@ -1,10 +1,10 @@
 package co.kr.tnt.trainee.mealrecord
 
-import android.content.Context
 import android.net.Uri
 import co.kr.tnt.ui.base.UiEvent
 import co.kr.tnt.ui.base.UiSideEffect
 import co.kr.tnt.ui.base.UiState
+import java.io.File
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -52,7 +52,7 @@ internal class TraineeMealRecordContract {
         data object OnClickCloseBottomSheet : TraineeMealRecordUiEvent
         data class OnSelectMealType(val mealType: String) : TraineeMealRecordUiEvent
         data class OnChangeMemo(val memo: String) : TraineeMealRecordUiEvent
-        data class OnClickSave(val context: Context) : TraineeMealRecordUiEvent
+        data class OnClickSave(val imageFile: File?) : TraineeMealRecordUiEvent
         data object OnClickBack : TraineeMealRecordUiEvent
         data object OnClickDialogConfirm : TraineeMealRecordUiEvent
         data object OnDismissDialog : TraineeMealRecordUiEvent

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
@@ -339,8 +339,8 @@ private fun Dialog(
                 content = "기록이 저장되지 않아요!",
                 leftButtonText = "취소",
                 rightButtonText = "확인",
-                onLeftButtonClick = onClickExit,
-                onRightButtonClick = onDismissDialog,
+                onLeftButtonClick = onDismissDialog,
+                onRightButtonClick = onClickExit,
                 onDismiss = onDismissDialog,
             )
         }

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
@@ -77,11 +77,15 @@ import co.kr.tnt.ui.coil.ResizeTransformation
 import co.kr.tnt.ui.component.TnTLoadingScreen
 import co.kr.tnt.ui.extensions.clearFocusOnTap
 import co.kr.tnt.ui.model.RecordChip
+import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.kizitonwose.calendar.compose.rememberCalendarState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
@@ -101,22 +105,30 @@ internal fun TraineeMealRecordRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val dateFormatter = remember { DateFormatter() }
 
+    var imageFile by rememberSaveable { mutableStateOf<File?>(null) }
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(selectedDate) {
         viewModel.setEvent(
             TraineeMealRecordUiEvent.OnSelectMealDate(
-                dateFormatter.parse(
-                    selectedDate,
-                ),
+                dateFormatter.parse(selectedDate),
             ),
         )
+    }
+
+    LaunchedEffect(state.image) {
+        state.image?.let { uri ->
+            withContext(Dispatchers.IO) {
+                val file = uri.convertToAllowedImageFormat(context)
+                imageFile = file
+            }
+        }
     }
 
     TraineeMealRecordScreen(
         state = state,
         context = context,
-        onImageSelect = { uri ->
+        onSelectImage = { uri ->
             viewModel.setEvent(TraineeMealRecordUiEvent.OnSelectImage(imageUri = uri))
         },
         onClickDeleteImage = { viewModel.setEvent(TraineeMealRecordUiEvent.OnClickDeleteImage) },
@@ -137,7 +149,7 @@ internal fun TraineeMealRecordRoute(
         onClickBack = {
             viewModel.setEvent(TraineeMealRecordUiEvent.OnClickBack)
         },
-        onClickSaveButton = { viewModel.setEvent(TraineeMealRecordUiEvent.OnClickSave(context)) },
+        onClickSaveButton = { viewModel.setEvent(TraineeMealRecordUiEvent.OnClickSave(imageFile)) },
     )
 
     if (showBottomSheet) {
@@ -201,7 +213,7 @@ internal fun TraineeMealRecordRoute(
 private fun TraineeMealRecordScreen(
     state: TraineeMealRecordUiState,
     context: Context,
-    onImageSelect: (url: Uri) -> Unit,
+    onSelectImage: (url: Uri) -> Unit,
     onClickDeleteImage: () -> Unit,
     onClickDateSection: () -> Unit,
     onClickTimeSection: () -> Unit,
@@ -214,7 +226,7 @@ private fun TraineeMealRecordScreen(
 
     val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
         if (uri != null) {
-            onImageSelect(uri)
+            onSelectImage(uri)
         }
     }
 
@@ -672,7 +684,7 @@ private fun TraineeMealRecordScreenPreview() {
                 memo = "",
             ),
             context = LocalContext.current,
-            onImageSelect = { },
+            onSelectImage = { },
             onClickDeleteImage = { },
             onClickDateSection = { },
             onClickTimeSection = { },

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
@@ -117,12 +117,10 @@ internal fun TraineeMealRecordRoute(
     }
 
     LaunchedEffect(state.image) {
-        state.image?.let { uri ->
-            withContext(Dispatchers.IO) {
-                val file = uri.convertToAllowedImageFormat(context)
-                imageFile = file
-            }
+        val file = withContext(Dispatchers.IO) {
+            state.image?.convertToAllowedImageFormat(context)
         }
+        imageFile = file
     }
 
     TraineeMealRecordScreen(

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordScreen.kt
@@ -85,7 +85,6 @@ import com.kizitonwose.calendar.compose.rememberCalendarState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
@@ -102,10 +101,10 @@ internal fun TraineeMealRecordRoute(
 
     val context = LocalContext.current
     val snackbar = LocalSnackbar.current
+    val coroutineScope = rememberCoroutineScope()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val dateFormatter = remember { DateFormatter() }
 
-    var imageFile by rememberSaveable { mutableStateOf<File?>(null) }
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(selectedDate) {
@@ -114,13 +113,6 @@ internal fun TraineeMealRecordRoute(
                 dateFormatter.parse(selectedDate),
             ),
         )
-    }
-
-    LaunchedEffect(state.image) {
-        val file = withContext(Dispatchers.IO) {
-            state.image?.convertToAllowedImageFormat(context)
-        }
-        imageFile = file
     }
 
     TraineeMealRecordScreen(
@@ -147,7 +139,14 @@ internal fun TraineeMealRecordRoute(
         onClickBack = {
             viewModel.setEvent(TraineeMealRecordUiEvent.OnClickBack)
         },
-        onClickSaveButton = { viewModel.setEvent(TraineeMealRecordUiEvent.OnClickSave(imageFile)) },
+        onClickSaveButton = {
+            coroutineScope.launch {
+                val imageFile = withContext(Dispatchers.IO) {
+                    state.image?.convertToAllowedImageFormat(context)
+                }
+                viewModel.setEvent(TraineeMealRecordUiEvent.OnClickSave(imageFile))
+            }
+        },
     )
 
     if (showBottomSheet) {

--- a/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordViewModel.kt
+++ b/feature/trainee/mealrecord/src/main/java/co/kr/tnt/trainee/mealrecord/TraineeMealRecordViewModel.kt
@@ -1,6 +1,5 @@
 package co.kr.tnt.trainee.mealrecord
 
-import android.content.Context
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.repository.TraineeRepository
 import co.kr.tnt.domain.utils.DateFormatter
@@ -9,7 +8,6 @@ import co.kr.tnt.trainee.mealrecord.TraineeMealRecordContract.TraineeMealRecordU
 import co.kr.tnt.trainee.mealrecord.TraineeMealRecordContract.TraineeMealRecordUiState
 import co.kr.tnt.trainee.mealrecord.TraineeMealRecordContract.TraineeMealRecordUiState.DialogState
 import co.kr.tnt.ui.base.BaseViewModel
-import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
@@ -45,14 +43,13 @@ internal class TraineeMealRecordViewModel @Inject constructor(
                 }
 
                 TraineeMealRecordUiEvent.OnClickCloseBottomSheet -> clearFocusState()
-
                 is TraineeMealRecordUiEvent.OnSelectMealType -> updateState {
                     copy(mealType = event.mealType).validateMealRecord()
                 }
 
                 is TraineeMealRecordUiEvent.OnChangeMemo -> updateMemo(event.memo)
                 TraineeMealRecordUiEvent.OnClickBack -> handleBackClick()
-                is TraineeMealRecordUiEvent.OnClickSave -> postMealRecord(event.context)
+                is TraineeMealRecordUiEvent.OnClickSave -> postMealRecord(event.imageFile)
                 TraineeMealRecordUiEvent.OnClickDialogConfirm -> {
                     updateState { copy(dialogState = DialogState.NONE) }
                     sendEffect(TraineeMealRecordSideEffect.NavigateToHome)
@@ -90,18 +87,15 @@ internal class TraineeMealRecordViewModel @Inject constructor(
             }
         }
 
-        // TODO Context 제거
-        private fun postMealRecord(context: Context) {
+        private fun postMealRecord(imageFile: File?) {
             updateState { copy(isLoading = true) }
 
             val mealDateTime = dateFormatter.format(
                 LocalDateTime.of(currentState.date, currentState.time),
                 "yyyy-MM-dd'T'HH:mm:ss",
             )
-
             viewModelScope.launch {
                 val state = currentState
-                val imageFile: File? = state.image?.convertToAllowedImageFormat(context)
                 runCatching {
                     traineeRepository.postMealRecord(
                         mealImage = imageFile,

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -29,6 +32,8 @@ import co.kr.tnt.ui.model.DefaultUserProfile
 import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import co.kr.tnt.core.ui.R as uiResource
 
@@ -41,9 +46,16 @@ internal fun TraineeSignUpCompletePage(
     BackHandler { onBackClick() }
 
     val context = LocalContext.current
-    val onClickComplete = {
-        val imageFile = state.image?.convertToAllowedImageFormat(context)
-        onNextClick(imageFile)
+    val completeState = remember { mutableStateOf(false) }
+
+    LaunchedEffect(completeState.value) {
+        if (completeState.value) {
+            val imageFile = withContext(Dispatchers.IO) {
+                state.image?.convertToAllowedImageFormat(context)
+            }
+            onNextClick(imageFile)
+            completeState.value = false
+        }
     }
 
     Scaffold(
@@ -87,7 +99,7 @@ internal fun TraineeSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onClickComplete() },
+                onClick = throttled { completeState.value = true },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
@@ -1,6 +1,5 @@
 package co.kr.tnt.trainee.signup
 
-import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -14,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign.Companion.Center
@@ -26,17 +26,25 @@ import co.kr.tnt.feature.trainee.signup.R
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpUiState
 import co.kr.tnt.ui.component.TnTLoadingScreen
 import co.kr.tnt.ui.model.DefaultUserProfile
+import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
+import java.io.File
 import co.kr.tnt.core.ui.R as uiResource
 
 @Composable
 internal fun TraineeSignUpCompletePage(
     state: TraineeSignUpUiState,
     onBackClick: () -> Unit,
-    onNextClick: (Uri?) -> Unit,
+    onNextClick: (image: File?) -> Unit,
 ) {
     BackHandler { onBackClick() }
+
+    val context = LocalContext.current
+    val onClickComplete = {
+        val imageFile = state.image?.convertToAllowedImageFormat(context)
+        onNextClick(imageFile)
+    }
 
     Scaffold(
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -79,7 +87,7 @@ internal fun TraineeSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onNextClick(state.image) },
+                onClick = throttled { onClickComplete() },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpContract.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpContract.kt
@@ -1,10 +1,10 @@
 package co.kr.tnt.trainee.signup
 
-import android.content.Context
 import android.net.Uri
 import co.kr.tnt.ui.base.UiEvent
 import co.kr.tnt.ui.base.UiSideEffect
 import co.kr.tnt.ui.base.UiState
+import java.io.File
 import java.time.LocalDate
 
 private const val MAX_NAME_LENGTH = 15
@@ -67,8 +67,7 @@ internal class TraineeSignUpContract {
         data object OnNextClick : TraineeSignUpUiEvent
         data object OnBackClick : TraineeSignUpUiEvent
         data class RequestSignUp(
-            val context: Context,
-            val imageUri: Uri?,
+            val imageFile: File?,
             val id: String,
             val email: String,
             val authType: String,

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpScreen.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpScreen.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.kr.tnt.designsystem.snackbar.LocalSnackbar
@@ -12,6 +11,7 @@ import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpEffect
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpPage
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpUiEvent
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpUiState
+import java.io.File
 import java.time.LocalDate
 
 @Composable
@@ -24,7 +24,6 @@ internal fun TraineeSignUpRoute(
     navigateToConnect: () -> Unit,
     viewModel: TraineeSignUpViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
     val snackbar = LocalSnackbar.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -39,11 +38,10 @@ internal fun TraineeSignUpRoute(
         onCautionChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnCautionChange(it)) },
         onBackClick = { viewModel.setEvent(TraineeSignUpUiEvent.OnBackClick) },
         onNextClick = { viewModel.setEvent(TraineeSignUpUiEvent.OnNextClick) },
-        onSubmitSignUp = { uri ->
+        onSubmitSignUp = { file ->
             viewModel.setEvent(
                 TraineeSignUpUiEvent.RequestSignUp(
-                    context = context,
-                    imageUri = uri,
+                    imageFile = file,
                     id = authId,
                     email = email,
                     authType = authType,
@@ -67,14 +65,14 @@ internal fun TraineeSignUpRoute(
 @Composable
 private fun TraineeSignUpScreen(
     state: TraineeSignUpUiState,
-    onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
-    onHeightChange: (String) -> Unit,
-    onWeightChange: (String) -> Unit,
-    onCautionChange: (String) -> Unit,
-    onBirthdayChange: (LocalDate) -> Unit,
-    onPurposeSelected: (String) -> Unit,
-    onSubmitSignUp: (Uri?) -> Unit,
+    onProfileImageSelect: (imageUri: Uri) -> Unit,
+    onNameChange: (name: String) -> Unit,
+    onHeightChange: (height: String) -> Unit,
+    onWeightChange: (weight: String) -> Unit,
+    onCautionChange: (caution: String) -> Unit,
+    onBirthdayChange: (birthday: LocalDate) -> Unit,
+    onPurposeSelected: (purpose: String) -> Unit,
+    onSubmitSignUp: (imageFile: File?) -> Unit,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpViewModel.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpViewModel.kt
@@ -1,6 +1,5 @@
 package co.kr.tnt.trainee.signup
 
-import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.model.User
@@ -10,7 +9,6 @@ import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpPage
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpUiEvent
 import co.kr.tnt.trainee.signup.TraineeSignUpContract.TraineeSignUpUiState
 import co.kr.tnt.ui.base.BaseViewModel
-import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
@@ -35,8 +33,7 @@ internal class TraineeSignUpViewModel @Inject constructor(
             TraineeSignUpUiEvent.OnBackClick -> navigateToBack()
             TraineeSignUpUiEvent.OnNextClick -> navigateToNext()
             is TraineeSignUpUiEvent.RequestSignUp -> signUp(
-                context = event.context,
-                imageUri = event.imageUri,
+                imageFile = event.imageFile,
                 id = event.id,
                 email = event.email,
                 authType = event.authType,
@@ -46,8 +43,7 @@ internal class TraineeSignUpViewModel @Inject constructor(
     }
 
     private fun signUp(
-        context: Context,
-        imageUri: Uri?,
+        imageFile: File?,
         id: String,
         email: String,
         authType: String,
@@ -57,11 +53,9 @@ internal class TraineeSignUpViewModel @Inject constructor(
             updateState { copy(isLoading = true) }
 
             val state = currentState
-            val profileImageFile: File? = imageUri?.convertToAllowedImageFormat(context)
-
             runCatching {
                 signUpRepository.signUp(
-                    profileImage = profileImageFile,
+                    profileImage = imageFile,
                     user = User.Trainee(
                         id = id,
                         name = state.name,

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
@@ -1,6 +1,5 @@
 package co.kr.tnt.trainer.signup
 
-import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -14,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign.Companion.Center
@@ -26,17 +26,25 @@ import co.kr.tnt.feature.trainer.signup.R
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpUiState
 import co.kr.tnt.ui.component.TnTLoadingScreen
 import co.kr.tnt.ui.model.DefaultUserProfile
+import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
+import java.io.File
 import co.kr.tnt.core.ui.R as uiResource
 
 @Composable
 internal fun TrainerSignUpCompletePage(
     state: TrainerSignUpUiState,
     onBackClick: () -> Unit,
-    onNextClick: (Uri?) -> Unit,
+    onNextClick: (image: File?) -> Unit,
 ) {
     BackHandler { onBackClick() }
+
+    val context = LocalContext.current
+    val onClickComplete = {
+        val imageFile = state.image?.convertToAllowedImageFormat(context)
+        onNextClick(imageFile)
+    }
 
     Scaffold(
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -79,12 +87,11 @@ internal fun TrainerSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onNextClick(state.image) },
+                onClick = throttled { onClickComplete() },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
     }
-
     if (state.isLoading) {
         TnTLoadingScreen()
     }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -29,6 +32,8 @@ import co.kr.tnt.ui.model.DefaultUserProfile
 import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import co.kr.tnt.core.ui.R as uiResource
 
@@ -41,9 +46,16 @@ internal fun TrainerSignUpCompletePage(
     BackHandler { onBackClick() }
 
     val context = LocalContext.current
-    val onClickComplete = {
-        val imageFile = state.image?.convertToAllowedImageFormat(context)
-        onNextClick(imageFile)
+    val completeState = remember { mutableStateOf(false) }
+
+    LaunchedEffect(completeState.value) {
+        if (completeState.value) {
+            val imageFile = withContext(Dispatchers.IO) {
+                state.image?.convertToAllowedImageFormat(context)
+            }
+            onNextClick(imageFile)
+            completeState.value = false
+        }
     }
 
     Scaffold(
@@ -87,7 +99,7 @@ internal fun TrainerSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onClickComplete() },
+                onClick = throttled { completeState.value = true },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,6 +31,7 @@ import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import co.kr.tnt.core.ui.R as uiResource
@@ -46,17 +45,7 @@ internal fun TrainerSignUpCompletePage(
     BackHandler { onBackClick() }
 
     val context = LocalContext.current
-    val completeState = remember { mutableStateOf(false) }
-
-    LaunchedEffect(completeState.value) {
-        if (completeState.value) {
-            val imageFile = withContext(Dispatchers.IO) {
-                state.image?.convertToAllowedImageFormat(context)
-            }
-            onNextClick(imageFile)
-            completeState.value = false
-        }
-    }
+    val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -99,7 +88,14 @@ internal fun TrainerSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { completeState.value = true },
+                onClick = throttled {
+                    coroutineScope.launch {
+                        val imageFile = withContext(Dispatchers.IO) {
+                            state.image?.convertToAllowedImageFormat(context)
+                        }
+                        onNextClick(imageFile)
+                    }
+                },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpContract.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpContract.kt
@@ -1,10 +1,10 @@
 package co.kr.tnt.trainer.signup
 
-import android.content.Context
 import android.net.Uri
 import co.kr.tnt.ui.base.UiEvent
 import co.kr.tnt.ui.base.UiSideEffect
 import co.kr.tnt.ui.base.UiState
+import java.io.File
 
 private const val MAX_LENGTH = 15
 
@@ -28,8 +28,7 @@ internal class TrainerSignUpContract {
         data object OnNextClick : TrainerSignUpUiEvent
         data object OnBackClick : TrainerSignUpUiEvent
         data class RequestSignUp(
-            val context: Context,
-            val imageUri: Uri?,
+            val imageFile: File?,
             val id: String,
             val email: String,
             val authType: String,

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpScreen.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpScreen.kt
@@ -4,13 +4,13 @@ import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.kr.tnt.designsystem.snackbar.LocalSnackbar
 import co.kr.tnt.navigation.model.ScreenMode
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpUiEvent
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpUiState
+import java.io.File
 
 @Composable
 internal fun TrainerSignUpRoute(
@@ -22,7 +22,6 @@ internal fun TrainerSignUpRoute(
     navigateToInvite: (ScreenMode) -> Unit,
     viewModel: TrainerSignUpViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
     val snackbar = LocalSnackbar.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -32,11 +31,10 @@ internal fun TrainerSignUpRoute(
         onProfileImageSelect = { viewModel.setEvent(TrainerSignUpUiEvent.OnImageChange(it)) },
         onNextClick = { viewModel.setEvent(TrainerSignUpUiEvent.OnNextClick) },
         onBackClick = { viewModel.setEvent(TrainerSignUpUiEvent.OnBackClick) },
-        onSubmitSignUp = { uri ->
+        onSubmitSignUp = { file ->
             viewModel.setEvent(
                 TrainerSignUpUiEvent.RequestSignUp(
-                    context = context,
-                    imageUri = uri,
+                    imageFile = file,
                     id = authId,
                     email = email,
                     authType = authType,
@@ -60,9 +58,9 @@ internal fun TrainerSignUpRoute(
 @Composable
 private fun TrainerSignUpScreen(
     state: TrainerSignUpUiState,
-    onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
-    onSubmitSignUp: (Uri?) -> Unit,
+    onProfileImageSelect: (imageUri: Uri) -> Unit,
+    onNameChange: (name: String) -> Unit,
+    onSubmitSignUp: (imageFile: File?) -> Unit,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
@@ -1,6 +1,5 @@
 package co.kr.tnt.trainer.signup
 
-import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import co.kr.tnt.domain.model.User
@@ -11,7 +10,6 @@ import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpPage
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpUiEvent
 import co.kr.tnt.trainer.signup.TrainerSignUpContract.TrainerSignUpUiState
 import co.kr.tnt.ui.base.BaseViewModel
-import co.kr.tnt.ui.utils.convertToAllowedImageFormat
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -31,8 +29,7 @@ internal class TrainerSignUpViewModel @Inject constructor(
             TrainerSignUpUiEvent.OnNextClick -> navigateToNext()
             TrainerSignUpUiEvent.OnBackClick -> navigateToBack()
             is TrainerSignUpUiEvent.RequestSignUp -> signUp(
-                context = event.context,
-                imageUri = event.imageUri,
+                imageFile = event.imageFile,
                 id = event.id,
                 email = event.email,
                 authType = event.authType,
@@ -42,8 +39,7 @@ internal class TrainerSignUpViewModel @Inject constructor(
     }
 
     private fun signUp(
-        context: Context,
-        imageUri: Uri?,
+        imageFile: File?,
         id: String,
         email: String,
         authType: String,
@@ -51,11 +47,10 @@ internal class TrainerSignUpViewModel @Inject constructor(
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             updateState { copy(isLoading = true) }
-            val profileImageFile: File? = imageUri?.convertToAllowedImageFormat(context)
 
             runCatching {
                 signUpRepository.signUp(
-                    profileImage = profileImageFile,
+                    profileImage = imageFile,
                     user = User.Trainer(
                         id = id,
                         name = currentState.name,


### PR DESCRIPTION
## 📝 작업 내용

- Closes #134
- Closes #133 
<br>

1. **ViewModel 내 Context 모두 제거**
    - 사진을 업로드하는 모든 화면에 쓰이는 ViewModel에서 이미지 파일 변환을 위해 사용한 Context를 제거했습니다.
        - `식단 기록`, `회원 가입`
    - 파일 변환은 UI 단에서 처리하고, 변환된 이미지 파일만 ViewModel로 전달하도록 구조를 변경했습니다.
<br>

3. **약관 노션 링크 수정**
    - 이전된 노션 페이지 링크로 약관 URL을 교체했습니다.
<br>

4. **식단 기록 중단 다이얼로그 버튼 동작 수정**
    - `취소`와 `확인` 버튼의 동작이 반대로 매핑되어있는 문제를 발견해 수정했습니다.
<br>

## 📸 실행 화면
- UI 변경사항 없습니다! 아래는 정상 작동 확인용 영상들입니다

#### 약관
https://github.com/user-attachments/assets/fa12de5e-bef7-4d9f-b581-fe2fb0a797af

#### 트레이너 회원가입
https://github.com/user-attachments/assets/cb1b2093-0e89-4582-8a22-7577be89cd00

#### 트레이니 회원가입
https://github.com/user-attachments/assets/145ff845-d677-4738-be5a-0f02b09f8b6f

#### 식단 기록
https://github.com/user-attachments/assets/dd5f8fbf-24b1-40a6-92bc-41b68557ca46



## 🙆🏻 리뷰 요청 사항



## 👀 레퍼런스

