### PR TITLE
[TNT-281] 네이밍 방식 통일

### DIFF
--- a/core/designsystem/src/main/java/co/kr/tnt/designsystem/component/Toggle.kt
+++ b/core/designsystem/src/main/java/co/kr/tnt/designsystem/component/Toggle.kt
@@ -32,7 +32,7 @@ import co.kr.tnt.designsystem.theme.TnTTheme
 @Composable
 fun TnTCheckToggle(
     isChecked: Boolean = false,
-    onCheckClick: () -> Unit,
+    onClickCheck: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val icon = if (isChecked) {
@@ -47,7 +47,7 @@ fun TnTCheckToggle(
         modifier = modifier
             .size(24.dp)
             .clip(CircleShape)
-            .clickable(onClick = onCheckClick),
+            .clickable(onClick = onClickCheck),
     )
 }
 
@@ -96,7 +96,7 @@ private fun TnTCheckTogglePreview() {
 
         TnTCheckToggle(
             isChecked = isChecked,
-            onCheckClick = { isChecked = !isChecked },
+            onClickCheck = { isChecked = !isChecked },
         )
     }
 }

--- a/core/ui/src/main/java/co/kr/tnt/ui/component/TnTCheckToggleDialog.kt
+++ b/core/ui/src/main/java/co/kr/tnt/ui/component/TnTCheckToggleDialog.kt
@@ -41,7 +41,7 @@ fun TnTCheckToggleDialog(
     onLeftButtonClick: () -> Unit,
     onRightButtonClick: () -> Unit,
     cancelable: Boolean = false,
-    onCheckClick: () -> Unit,
+    onClickCheck: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     Dialog(
@@ -88,7 +88,7 @@ fun TnTCheckToggleDialog(
                 ) {
                     TnTCheckToggle(
                         isChecked = isChecked,
-                        onCheckClick = onCheckClick,
+                        onClickCheck = onClickCheck,
                     )
                     Text(
                         text = checkToggleText,
@@ -96,7 +96,7 @@ fun TnTCheckToggleDialog(
                         color = TnTTheme.colors.neutralColors.Neutral500,
                         modifier = Modifier
                             .padding(start = 4.dp)
-                            .clickable(onClick = onCheckClick),
+                            .clickable(onClick = onClickCheck),
                     )
                 }
                 Row(
@@ -135,7 +135,7 @@ private fun TnTCheckToggleDialogPreview() {
             isChecked = isChecked,
             onLeftButtonClick = {},
             onRightButtonClick = {},
-            onCheckClick = { isChecked = !isChecked },
+            onClickCheck = { isChecked = !isChecked },
             leftButtonText = "다음에",
             rightButtonText = "연결하기",
             onDismiss = {},

--- a/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionContract.kt
+++ b/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionContract.kt
@@ -11,7 +11,7 @@ internal class RoleSelectionContract {
     ) : UiState
 
     sealed interface RoleSelectionUiEvent : UiEvent {
-        data class OnNextClick(val role: RoleState) : RoleSelectionUiEvent
+        data class OnClickNext(val role: RoleState) : RoleSelectionUiEvent
     }
 
     sealed interface RoleSelectionEffect : UiSideEffect {

--- a/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionScreen.kt
+++ b/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionScreen.kt
@@ -45,7 +45,7 @@ internal fun RoleSelectionRoute(
     navigateToTrainerSignUp: () -> Unit,
 ) {
     RoleSelectionScreen(
-        onNextClick = { viewModel.setEvent(RoleSelectionUiEvent.OnNextClick(it)) },
+        onClickNext = { viewModel.setEvent(RoleSelectionUiEvent.OnClickNext(it)) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -60,7 +60,7 @@ internal fun RoleSelectionRoute(
 
 @Composable
 fun RoleSelectionScreen(
-    onNextClick: (RoleState) -> Unit = {},
+    onClickNext: (RoleState) -> Unit = {},
 ) {
     var selectedRole by remember { mutableStateOf(RoleState.fromDomain(UserType.TRAINER)) }
 
@@ -69,7 +69,7 @@ fun RoleSelectionScreen(
             TnTBottomButton(
                 text = stringResource(uiResource.string.next),
                 enabled = true,
-                onClick = { onNextClick(selectedRole) },
+                onClick = { onClickNext(selectedRole) },
                 modifier = Modifier.navigationBarsPadding(),
             )
         },
@@ -112,7 +112,11 @@ fun RoleSelectionScreen(
                     text = stringResource(RoleState.Trainer.textResId),
                     modifier = Modifier.weight(1f),
                     size = ButtonSize.Large,
-                    type = if (selectedRole == RoleState.Trainer) ButtonType.RedOutline else ButtonType.GrayOutline,
+                    type = if (selectedRole == RoleState.Trainer) {
+                        ButtonType.RedOutline
+                    } else {
+                        ButtonType.GrayOutline
+                    },
                     onClick = {
                         selectedRole = RoleState.Trainer
                     },
@@ -121,7 +125,11 @@ fun RoleSelectionScreen(
                     text = stringResource(RoleState.Trainee.textResId),
                     modifier = Modifier.weight(1f),
                     size = ButtonSize.Large,
-                    type = if (selectedRole == RoleState.Trainee) ButtonType.RedOutline else ButtonType.GrayOutline,
+                    type = if (selectedRole == RoleState.Trainee) {
+                        ButtonType.RedOutline
+                    } else {
+                        ButtonType.GrayOutline
+                    },
                     onClick = {
                         selectedRole = RoleState.Trainee
                     },
@@ -137,7 +145,7 @@ fun RoleSelectionScreen(
 private fun RoleScreenPreview() {
     TnTTheme {
         RoleSelectionScreen(
-            onNextClick = {},
+            onClickNext = { },
         )
     }
 }

--- a/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionViewModel.kt
+++ b/feature/roleselect/src/main/java/co/kr/tnt/roleselect/RoleSelectionViewModel.kt
@@ -15,7 +15,7 @@ internal class RoleSelectionViewModel @Inject constructor() :
     ) {
         override suspend fun handleEvent(event: RoleSelectionUiEvent) {
             when (event) {
-                is RoleSelectionUiEvent.OnNextClick -> navigateToSignUp(event.role)
+                is RoleSelectionUiEvent.OnClickNext -> navigateToSignUp(event.role)
             }
         }
 

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/CodeEntryPage.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/CodeEntryPage.kt
@@ -39,19 +39,19 @@ internal fun CodeEntryPage(
     inviteCode: String,
     inputState: InputState,
     screenMode: ScreenMode,
-    onSkipClick: () -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onClickSkip: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
     onChangeInviteCode: (code: String) -> Unit,
-    onValidateClick: (code: String) -> Unit,
-    onCancelClick: () -> Unit,
-    onDismissPopup: () -> Unit,
+    onClickValidate: (code: String) -> Unit,
+    onClickCancel: () -> Unit,
+    onDismissDialog: () -> Unit,
 ) {
     BackHandler {
         when (screenMode) {
-            ScreenMode.BACK -> onBackClick()
-            ScreenMode.SKIP -> onSkipClick()
-            ScreenMode.CLOSE -> onBackClick()
+            ScreenMode.BACK -> onClickBack()
+            ScreenMode.SKIP -> onClickSkip()
+            ScreenMode.CLOSE -> onClickBack()
         }
     }
 
@@ -61,7 +61,7 @@ internal fun CodeEntryPage(
                 ScreenMode.BACK -> {
                     TnTTopBarWithBackButton(
                         title = stringResource(coreR.string.connect),
-                        onBackClick = onBackClick,
+                        onBackClick = onClickBack,
                     )
                 }
                 ScreenMode.SKIP -> {
@@ -72,9 +72,7 @@ internal fun CodeEntryPage(
                                 text = stringResource(coreR.string.skip),
                                 color = TnTTheme.colors.neutralColors.Neutral400,
                                 style = TnTTheme.typography.body2Medium,
-                                modifier = Modifier.clickable {
-                                    onSkipClick()
-                                },
+                                modifier = Modifier.clickable { onClickSkip() },
                             )
                         },
                     )
@@ -84,7 +82,7 @@ internal fun CodeEntryPage(
                         title = stringResource(coreR.string.connect),
                         trailingComponent = {
                             IconButton(
-                                onClick = onBackClick,
+                                onClick = onClickBack,
                             ) {
                                 Icon(
                                     painter = painterResource(uiResource.drawable.ic_delete),
@@ -119,7 +117,7 @@ internal fun CodeEntryPage(
                             text = stringResource(R.string.verification),
                             size = ButtonSize.Small,
                             enabled = inviteCode.isNotBlank(),
-                            onClick = { onValidateClick(inviteCode) },
+                            onClick = { onClickValidate(inviteCode) },
                         )
                     },
                 )
@@ -127,7 +125,7 @@ internal fun CodeEntryPage(
             TnTBottomButton(
                 text = stringResource(coreR.string.next),
                 enabled = inputState.isValid,
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -139,9 +137,9 @@ internal fun CodeEntryPage(
             content = stringResource(R.string.warning_reconnect_needed),
             leftButtonText = stringResource(coreR.string.cancel),
             rightButtonText = stringResource(coreR.string.ok),
-            onLeftButtonClick = onCancelClick,
-            onRightButtonClick = onDismissPopup,
-            onDismiss = onDismissPopup,
+            onLeftButtonClick = onClickCancel,
+            onRightButtonClick = onDismissDialog,
+            onDismiss = onDismissDialog,
         )
     }
 }
@@ -155,13 +153,13 @@ private fun CodeEntryPagePreview() {
             inputState = InputState.FOCUS,
             inviteCode = "23A4SDA31",
             screenMode = ScreenMode.CLOSE,
-            onSkipClick = {},
-            onNextClick = {},
-            onValidateClick = {},
-            onChangeInviteCode = {},
-            onBackClick = {},
-            onDismissPopup = {},
-            onCancelClick = {},
+            onClickSkip = { },
+            onClickNext = { },
+            onClickBack = { },
+            onClickValidate = { },
+            onChangeInviteCode = { },
+            onDismissDialog = { },
+            onClickCancel = { },
         )
     }
 }

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/PTSessionFormPage.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/PTSessionFormPage.kt
@@ -51,10 +51,10 @@ internal fun PTSessionFormPage(
     onChangeSessionStartDate: (date: LocalDate) -> Unit,
     onChangeCompletedSessionCount: (count: String) -> Unit,
     onChangeTotalSessionCount: (count: String) -> Unit,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickNext: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val today = LocalDate.now()
 
@@ -84,7 +84,7 @@ internal fun PTSessionFormPage(
         topBar = {
             TnTTopBarWithBackButton(
                 title = stringResource(R.string.add_pt_info),
-                onBackClick = onBackClick,
+                onBackClick = onClickBack,
             )
         },
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -210,7 +210,7 @@ internal fun PTSessionFormPage(
                 text = stringResource(uiResource.string.next),
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = isFormValid,
-                onClick = throttled { onNextClick() },
+                onClick = throttled { onClickNext() },
             )
         }
     }
@@ -311,8 +311,8 @@ private fun PTSessionFormPagePreview() {
             completedSessionCount = "15",
             totalSessionCount = "10",
             isLoading = false,
-            onNextClick = { },
-            onBackClick = { },
+            onClickNext = { },
+            onClickBack = { },
             onChangeSessionStartDate = { },
             onChangeCompletedSessionCount = { },
             onChangeTotalSessionCount = { },

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectCompletePage.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectCompletePage.kt
@@ -42,10 +42,10 @@ internal fun TraineeConnectCompletePage(
     trainerImage: String,
     traineeName: String,
     traineeImage: String,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickNext: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
 
@@ -108,7 +108,7 @@ internal fun TraineeConnectCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.next),
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -162,8 +162,8 @@ private fun TraineeConnectCompletePagePreview() {
             trainerImage = "",
             traineeName = "김회원",
             traineeImage = "",
-            onNextClick = {},
-            onBackClick = {},
+            onClickNext = { },
+            onClickBack = { },
         )
     }
 }

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectContract.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectContract.kt
@@ -23,15 +23,15 @@ internal class TraineeConnectContract {
     ) : UiState
 
     sealed interface TraineeConnectUiEvent : UiEvent {
-        data class OnCodeValidateClick(val code: String) : TraineeConnectUiEvent
+        data class OnClickValidateCode(val code: String) : TraineeConnectUiEvent
         data class OnChangeInviteCode(val code: String) : TraineeConnectUiEvent
         data object OnChangeDialogState : TraineeConnectUiEvent
         data class OnChangeSessionStartDate(val date: LocalDate) : TraineeConnectUiEvent
         data class OnChangeCompletedSessionCount(val count: String) : TraineeConnectUiEvent
         data class OnChangeTotalSessionCount(val count: String) : TraineeConnectUiEvent
-        data object OnNextClick : TraineeConnectUiEvent
-        data object OnBackClick : TraineeConnectUiEvent
-        data object OnSkipClick : TraineeConnectUiEvent
+        data object OnClickNext : TraineeConnectUiEvent
+        data object OnClickBack : TraineeConnectUiEvent
+        data object OnClickSkip : TraineeConnectUiEvent
     }
 
     sealed interface TraineeConnectSideEffect : UiSideEffect {

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectScreen.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectScreen.kt
@@ -26,17 +26,17 @@ internal fun TraineeConnectRoute(
     TraineeConnectScreen(
         state = state,
         screenMode = screenMode,
-        onBackClick = { viewModel.setEvent(TraineeConnectUiEvent.OnChangeDialogState) },
-        onNextClick = { viewModel.setEvent(TraineeConnectUiEvent.OnNextClick) },
-        onSkipClick = { viewModel.setEvent(TraineeConnectUiEvent.OnSkipClick) },
+        onClickBack = { viewModel.setEvent(TraineeConnectUiEvent.OnChangeDialogState) },
+        onClickNext = { viewModel.setEvent(TraineeConnectUiEvent.OnClickNext) },
+        onClickSkip = { viewModel.setEvent(TraineeConnectUiEvent.OnClickSkip) },
         onChangeInviteCode = { code ->
             viewModel.setEvent(TraineeConnectUiEvent.OnChangeInviteCode(code))
         },
-        onCodeValidationClick = { code ->
-            viewModel.setEvent(TraineeConnectUiEvent.OnCodeValidateClick(code))
+        onClickValidateCode = { code ->
+            viewModel.setEvent(TraineeConnectUiEvent.OnClickValidateCode(code))
         },
-        onCancelConnectClick = { viewModel.setEvent(TraineeConnectUiEvent.OnBackClick) },
-        onDismissPopUp = { viewModel.setEvent(TraineeConnectUiEvent.OnChangeDialogState) },
+        onClickCancelConnection = { viewModel.setEvent(TraineeConnectUiEvent.OnClickBack) },
+        onDismissDialog = { viewModel.setEvent(TraineeConnectUiEvent.OnChangeDialogState) },
         onChangeSessionStartDate = { date ->
             viewModel.setEvent(TraineeConnectUiEvent.OnChangeSessionStartDate(date))
         },
@@ -64,15 +64,15 @@ private fun TraineeConnectScreen(
     state: TraineeConnectUiState,
     screenMode: ScreenMode,
     onChangeInviteCode: (code: String) -> Unit,
-    onCodeValidationClick: (code: String) -> Unit,
-    onCancelConnectClick: () -> Unit,
-    onDismissPopUp: () -> Unit,
+    onClickValidateCode: (code: String) -> Unit,
+    onClickCancelConnection: () -> Unit,
+    onDismissDialog: () -> Unit,
     onChangeSessionStartDate: (date: LocalDate) -> Unit,
     onChangeCompletedSessionCount: (count: String) -> Unit,
     onChangeTotalSessionCount: (count: String) -> Unit,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
-    onSkipClick: () -> Unit,
+    onClickNext: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickSkip: () -> Unit,
 ) {
     when (state.page) {
         TraineeConnectPage.CodeEntry -> CodeEntryPage(
@@ -80,13 +80,13 @@ private fun TraineeConnectScreen(
             inputState = state.inviteCodeInputState,
             inviteCode = state.inviteCode,
             screenMode = screenMode,
-            onNextClick = onNextClick,
-            onBackClick = onBackClick,
-            onSkipClick = onSkipClick,
+            onClickNext = onClickNext,
+            onClickBack = onClickBack,
+            onClickSkip = onClickSkip,
             onChangeInviteCode = onChangeInviteCode,
-            onValidateClick = onCodeValidationClick,
-            onCancelClick = onCancelConnectClick,
-            onDismissPopup = onDismissPopUp,
+            onClickValidate = onClickValidateCode,
+            onClickCancel = onClickCancelConnection,
+            onDismissDialog = onDismissDialog,
         )
 
         TraineeConnectPage.PTSessionForm -> PTSessionFormPage(
@@ -98,8 +98,8 @@ private fun TraineeConnectScreen(
             onChangeSessionStartDate = onChangeSessionStartDate,
             onChangeCompletedSessionCount = onChangeCompletedSessionCount,
             onChangeTotalSessionCount = onChangeTotalSessionCount,
-            onNextClick = onNextClick,
-            onBackClick = onBackClick,
+            onClickNext = onClickNext,
+            onClickBack = onClickBack,
         )
 
         TraineeConnectPage.TraineeConnectComplete -> TraineeConnectCompletePage(
@@ -107,8 +107,8 @@ private fun TraineeConnectScreen(
             trainerImage = state.trainerImage,
             traineeName = state.traineeName,
             traineeImage = state.traineeImage,
-            onNextClick = onNextClick,
-            onBackClick = onBackClick,
+            onClickNext = onClickNext,
+            onClickBack = onClickBack,
         )
     }
 }

--- a/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectViewModel.kt
+++ b/feature/trainee/connect/src/main/java/co/kr/tnt/trainee/connect/TraineeConnectViewModel.kt
@@ -24,25 +24,21 @@ internal class TraineeConnectViewModel @Inject constructor(
         ) {
         override suspend fun handleEvent(event: TraineeConnectUiEvent) {
             when (event) {
-                is TraineeConnectUiEvent.OnCodeValidateClick -> validateInviteCode(event.code)
-                is TraineeConnectUiEvent.OnChangeInviteCode -> handleChangeInviteCode(event.code)
+                is TraineeConnectUiEvent.OnClickValidateCode -> validateInviteCode(event.code)
+                is TraineeConnectUiEvent.OnChangeInviteCode -> handleInviteCodeChange(event.code)
                 is TraineeConnectUiEvent.OnChangeSessionStartDate -> updateState { copy(sessionStartDate = event.date) }
-                TraineeConnectUiEvent.OnChangeDialogState -> handleChangeDialogState()
+                TraineeConnectUiEvent.OnChangeDialogState -> handleDialogState()
                 is TraineeConnectUiEvent.OnChangeCompletedSessionCount -> updateState {
-                    copy(
-                        completedSessionCount = event.count,
-                    )
+                    copy(completedSessionCount = event.count)
                 }
 
                 is TraineeConnectUiEvent.OnChangeTotalSessionCount -> updateState {
-                    copy(
-                        totalSessionCount = event.count,
-                    )
+                    copy(totalSessionCount = event.count)
                 }
 
-                is TraineeConnectUiEvent.OnNextClick -> handleNextClick()
-                TraineeConnectUiEvent.OnBackClick -> navigateToBack()
-                TraineeConnectUiEvent.OnSkipClick -> navigateToHome()
+                is TraineeConnectUiEvent.OnClickNext -> handleNextClick()
+                TraineeConnectUiEvent.OnClickBack -> navigateToBack()
+                TraineeConnectUiEvent.OnClickSkip -> navigateToHome()
             }
         }
 
@@ -62,7 +58,7 @@ internal class TraineeConnectViewModel @Inject constructor(
             }
         }
 
-        private fun handleChangeInviteCode(inviteCode: String) {
+        private fun handleInviteCodeChange(inviteCode: String) {
             updateState {
                 copy(
                     inviteCode = inviteCode,
@@ -109,7 +105,7 @@ internal class TraineeConnectViewModel @Inject constructor(
 
         private fun navigateToBack() {
             if (currentState.page == TraineeConnectPage.firstPage) {
-                handleChangeDialogState()
+                handleDialogState()
                 sendEffect(TraineeConnectSideEffect.NavigateToBack)
                 return
             }
@@ -122,10 +118,11 @@ internal class TraineeConnectViewModel @Inject constructor(
             updateState { copy(page = TraineeConnectPage.getPreviousPage(currentState.page)) }
         }
 
-        private fun handleChangeDialogState() {
+        private fun handleDialogState() {
             if (currentState.inviteCodeInputState == VALID) {
                 updateState { copy(showDialog = !showDialog) }
             } else {
+                updateState { copy(showDialog = false) }
                 sendEffect(TraineeConnectSideEffect.NavigateToBack)
                 return
             }

--- a/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeScreen.kt
+++ b/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeScreen.kt
@@ -137,7 +137,7 @@ internal fun TraineeHomeRoute(
             rightButtonText = stringResource(coreR.string.connect),
             onLeftButtonClick = { viewModel.setEvent(TraineeHomeUiEvent.OnDismissDialog) },
             onRightButtonClick = { viewModel.setEvent(TraineeHomeUiEvent.OnConfirmConnectDialog) },
-            onCheckClick = { viewModel.setEvent(TraineeHomeUiEvent.OnChangeHideDialogOption) },
+            onClickCheck = { viewModel.setEvent(TraineeHomeUiEvent.OnChangeHideDialogOption) },
             onDismiss = { viewModel.setEvent(TraineeHomeUiEvent.OnDismissDialog) },
         )
     }

--- a/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeViewModel.kt
+++ b/feature/trainee/home/src/main/java/co/kr/tnt/trainee/home/TraineeHomeViewModel.kt
@@ -35,7 +35,7 @@ internal class TraineeHomeViewModel @Inject constructor(
         when (event) {
             TraineeHomeUiEvent.OnScreen -> refresh()
             is TraineeHomeUiEvent.OnChangeVisibleMonth -> handleChangeVisibleMonth(event.yearMonth)
-            is TraineeHomeUiEvent.OnClickDay -> selectDate(event.date)
+            is TraineeHomeUiEvent.OnClickDay -> selectDay(event.date)
             is TraineeHomeUiEvent.OnClickPtSessionCard -> checkSessionRecord(event.ptSessionId)
             TraineeHomeUiEvent.OnClickExerciseRecord -> sendEffect(TraineeHomeEffect.NavigateToExerciseRecord)
             TraineeHomeUiEvent.OnClickMealRecord -> sendEffect(TraineeHomeEffect.NavigateToMealRecord)
@@ -93,7 +93,7 @@ internal class TraineeHomeViewModel @Inject constructor(
         // TODO: pt 수업 기록 확인 화면 이동
     }
 
-    private fun selectDate(date: LocalDate) {
+    private fun selectDay(date: LocalDate) {
         viewModelScope.launch {
             runCatching {
                 traineeRepository.getDailyRecord(date)
@@ -150,7 +150,7 @@ internal class TraineeHomeViewModel @Inject constructor(
     private fun refresh() {
         cachedMonthlyRecordState.clear()
         handleChangeVisibleMonth(currentState.selectedDay.yearMonth)
-        selectDate(currentState.selectedDay)
+        selectDay(currentState.selectedDay)
         showConnectDialog()
     }
 

--- a/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationContract.kt
+++ b/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationContract.kt
@@ -11,7 +11,7 @@ internal class TraineeNotificationContract {
     ) : UiState
 
     sealed interface TraineeNotificationUiEvent : UiEvent {
-        data object OnBackClick : TraineeNotificationUiEvent
+        data object OnClickBack : TraineeNotificationUiEvent
     }
 
     sealed interface TraineeNotificationEffect : UiSideEffect {

--- a/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationScreen.kt
+++ b/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationScreen.kt
@@ -37,7 +37,7 @@ internal fun TraineeNotificationRoute(
 
     TraineeNotificationScreen(
         state = uiState,
-        onBackClick = { viewModel.setEvent(TraineeNotificationUiEvent.OnBackClick) },
+        onClickBack = { viewModel.setEvent(TraineeNotificationUiEvent.OnClickBack) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -53,13 +53,13 @@ internal fun TraineeNotificationRoute(
 @Composable
 private fun TraineeNotificationScreen(
     state: TraineeNotificationUiState,
-    onBackClick: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
     Scaffold(
         topBar = {
             TnTTopBarWithBackButton(
                 title = stringResource(uiResource.string.notification),
-                onBackClick = onBackClick,
+                onBackClick = onClickBack,
                 showStoke = true,
             )
         },
@@ -124,7 +124,7 @@ private fun TraineeNotificationScreenPreview() {
             ),
         )
         TraineeNotificationScreen(
-            onBackClick = {},
+            onClickBack = {},
             state = TraineeNotificationUiState(notifications = sampleNotifications),
         )
     }

--- a/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationViewModel.kt
+++ b/feature/trainee/notification/src/main/java/co/kr/tnt/trainee/notification/TraineeNotificationViewModel.kt
@@ -20,7 +20,7 @@ internal class TraineeNotificationViewModel @Inject constructor() :
 
         override suspend fun handleEvent(event: TraineeNotificationUiEvent) {
             when (event) {
-                TraineeNotificationUiEvent.OnBackClick -> navigateToBack()
+                TraineeNotificationUiEvent.OnClickBack -> navigateToBack()
             }
         }
 

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeBasicInfoPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeBasicInfoPage.kt
@@ -44,19 +44,19 @@ import co.kr.tnt.core.ui.R as uiResource
 @Composable
 internal fun TraineeBasicInfoPage(
     state: TraineeSignUpUiState,
-    onHeightChange: (String) -> Unit,
-    onWeightChange: (String) -> Unit,
-    onBirthdayChange: (LocalDate) -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onChangeHeight: (String) -> Unit,
+    onChangeWeight: (String) -> Unit,
+    onChangeBirthday: (LocalDate) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
     val today = LocalDate.now()
 
     Scaffold(
-        topBar = { TnTTopBarWithBackButton(onBackClick = onBackClick) },
+        topBar = { TnTTopBarWithBackButton(onBackClick = onClickBack) },
         containerColor = TnTTheme.colors.commonColors.Common0,
         modifier = Modifier.clearFocusOnTap(),
     ) { innerPadding ->
@@ -86,7 +86,7 @@ internal fun TraineeBasicInfoPage(
                     context = context,
                     today = today,
                     selectedDate = state.birthday,
-                    onDateSelected = onBirthdayChange,
+                    onDateSelected = onChangeBirthday,
                 )
                 HorizontalDivider(
                     thickness = 1.dp,
@@ -111,7 +111,7 @@ internal fun TraineeBasicInfoPage(
                         trailingComponent = {
                             UnitLabel(uiResource.string.height_unit)
                         },
-                        onValueChange = onHeightChange,
+                        onValueChange = onChangeHeight,
                         modifier = Modifier.weight(1f),
                     )
                     TnTLabeledTextField(
@@ -125,7 +125,7 @@ internal fun TraineeBasicInfoPage(
                         trailingComponent = {
                             UnitLabel(uiResource.string.weight_unit)
                         },
-                        onValueChange = onWeightChange,
+                        onValueChange = onChangeWeight,
                         modifier = Modifier.weight(1f),
                     )
                 }
@@ -134,7 +134,7 @@ internal fun TraineeBasicInfoPage(
                 text = stringResource(uiResource.string.next),
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = state.isBasicInfoValid,
-                onClick = onNextClick,
+                onClick = onClickNext,
             )
         }
     }
@@ -207,11 +207,11 @@ private fun TraineeBasicInfoPagePreview() {
     TnTTheme {
         TraineeBasicInfoPage(
             state = TraineeSignUpUiState(),
-            onBackClick = {},
-            onNextClick = {},
-            onHeightChange = {},
-            onWeightChange = {},
-            onBirthdayChange = {},
+            onClickBack = {},
+            onClickNext = {},
+            onChangeHeight = {},
+            onChangeWeight = {},
+            onChangeBirthday = {},
         )
     }
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeNoteForTrainerPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeNoteForTrainerPage.kt
@@ -31,14 +31,14 @@ private const val MAX_LENGTH = 100
 @Composable
 internal fun TraineeNoteForTrainerPage(
     caution: String?,
-    onCautionChange: (String) -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onChangeCaution: (String) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     Scaffold(
-        topBar = { TnTTopBarWithBackButton(onBackClick = onBackClick) },
+        topBar = { TnTTopBarWithBackButton(onBackClick = onClickBack) },
         containerColor = TnTTheme.colors.commonColors.Common0,
         modifier = Modifier.clearFocusOnTap(),
     ) { innerPadding ->
@@ -60,7 +60,7 @@ internal fun TraineeNoteForTrainerPage(
                 TnTOutlinedTextField(
                     value = caution ?: "",
                     onValueChange = { newValue ->
-                        onCautionChange(newValue)
+                        onChangeCaution(newValue)
                     },
                     modifier = Modifier.padding(horizontal = 20.dp),
                     isError = (caution?.length ?: 0) >= MAX_LENGTH,
@@ -72,7 +72,7 @@ internal fun TraineeNoteForTrainerPage(
                 text = stringResource(uiResource.string.next),
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = (caution?.length ?: 0) < MAX_LENGTH,
-                onClick = onNextClick,
+                onClick = onClickNext,
             )
         }
     }
@@ -84,9 +84,9 @@ private fun TraineeNoteForTrainerPagePreview() {
     TnTTheme {
         TraineeNoteForTrainerPage(
             caution = "",
-            onBackClick = {},
-            onNextClick = {},
-            onCautionChange = {},
+            onClickBack = {},
+            onClickNext = {},
+            onChangeCaution = {},
         )
     }
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineePTPurposePage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineePTPurposePage.kt
@@ -36,14 +36,14 @@ private const val COLUMNS_NUM = 2
 @Composable
 internal fun TraineePTPurposePage(
     state: TraineeSignUpUiState,
-    onPurposeSelected: (String) -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onSelectPurpose: (String) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     Scaffold(
-        topBar = { TnTTopBarWithBackButton(onBackClick = onBackClick) },
+        topBar = { TnTTopBarWithBackButton(onBackClick = onClickBack) },
         containerColor = TnTTheme.colors.commonColors.Common0,
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
@@ -68,7 +68,7 @@ internal fun TraineePTPurposePage(
                             PurposeButton(
                                 text = purposeText,
                                 isSelected = state.ptPurpose?.contains(purposeText) == true,
-                                onClick = { onPurposeSelected(purposeText) },
+                                onClick = { onSelectPurpose(purposeText) },
                                 modifier = Modifier.weight(1f),
                             )
                         }
@@ -77,7 +77,7 @@ internal fun TraineePTPurposePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.next),
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -106,9 +106,9 @@ private fun TraineePTPurposePagePreview() {
     TnTTheme {
         TraineePTPurposePage(
             state = TraineeSignUpUiState(),
-            onBackClick = {},
-            onNextClick = {},
-            onPurposeSelected = {},
+            onClickBack = {},
+            onClickNext = {},
+            onSelectPurpose = {},
         )
     }
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupPage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeProfileSetupPage.kt
@@ -46,11 +46,11 @@ private const val MAX_LENGTH = 15
 internal fun TraineeProfileSetupPage(
     state: TraineeSignUpUiState,
     onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onChangeName: (String) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
     val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
@@ -66,7 +66,7 @@ internal fun TraineeProfileSetupPage(
     )
 
     Scaffold(
-        topBar = { TnTTopBarWithBackButton(onBackClick = onBackClick) },
+        topBar = { TnTTopBarWithBackButton(onBackClick = onClickBack) },
         containerColor = TnTTheme.colors.commonColors.Common0,
         modifier = Modifier.clearFocusOnTap(),
     ) { innerPadding ->
@@ -103,7 +103,7 @@ internal fun TraineeProfileSetupPage(
                     title = stringResource(coreR.string.name),
                     value = state.name,
                     onValueChange = { newValue ->
-                        onNameChange(newValue)
+                        onChangeName(newValue)
                     },
                     modifier = Modifier.padding(horizontal = 20.dp),
                     placeholder = stringResource(R.string.enter_your_name),
@@ -117,7 +117,7 @@ internal fun TraineeProfileSetupPage(
             TnTBottomButton(
                 text = stringResource(coreR.string.next),
                 enabled = state.name.isNotBlank() && state.isNameValid,
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -130,10 +130,10 @@ private fun TraineeProfileSetupPagePreview() {
     TnTTheme {
         TraineeProfileSetupPage(
             state = TraineeSignUpUiState(),
-            onBackClick = {},
-            onNextClick = {},
+            onClickBack = {},
+            onClickNext = {},
             onProfileImageSelect = {},
-            onNameChange = {},
+            onChangeName = {},
         )
     }
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpCompletePage.kt
@@ -33,10 +33,10 @@ import co.kr.tnt.core.ui.R as uiResource
 @Composable
 internal fun TraineeSignUpCompletePage(
     state: TraineeSignUpUiState,
-    onBackClick: () -> Unit,
-    onNextClick: (Uri?) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: (Uri?) -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     Scaffold(
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -79,7 +79,7 @@ internal fun TraineeSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onNextClick(state.image) },
+                onClick = throttled { onClickNext(state.image) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -95,8 +95,8 @@ internal fun TraineeSignUpCompletePage(
 private fun TraineeSignUpCompletePagePreview() {
     TnTTheme {
         TraineeSignUpCompletePage(
-            onBackClick = {},
-            onNextClick = {},
+            onClickBack = {},
+            onClickNext = {},
             state = TraineeSignUpUiState(name = "김회원"),
         )
     }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpContract.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpContract.kt
@@ -57,15 +57,15 @@ internal class TraineeSignUpContract {
     }
 
     sealed interface TraineeSignUpUiEvent : UiEvent {
-        data class OnImageChange(val imageUri: Uri) : TraineeSignUpUiEvent
-        data class OnNameChange(val name: String) : TraineeSignUpUiEvent
-        data class OnHeightChange(val height: String) : TraineeSignUpUiEvent
-        data class OnWeightChange(val weight: String) : TraineeSignUpUiEvent
-        data class OnBirthdayChange(val birthday: LocalDate) : TraineeSignUpUiEvent
-        data class OnPurposeSelected(val purpose: String) : TraineeSignUpUiEvent
-        data class OnCautionChange(val text: String) : TraineeSignUpUiEvent
-        data object OnNextClick : TraineeSignUpUiEvent
-        data object OnBackClick : TraineeSignUpUiEvent
+        data class OnChangeImage(val imageUri: Uri) : TraineeSignUpUiEvent
+        data class OnChangeName(val name: String) : TraineeSignUpUiEvent
+        data class OnChangeHeight(val height: String) : TraineeSignUpUiEvent
+        data class OnChangeWeight(val weight: String) : TraineeSignUpUiEvent
+        data class OnChangeBirthday(val birthday: LocalDate) : TraineeSignUpUiEvent
+        data class OnSelectPurpose(val purpose: String) : TraineeSignUpUiEvent
+        data class OnChangeCaution(val text: String) : TraineeSignUpUiEvent
+        data object OnClickNext : TraineeSignUpUiEvent
+        data object OnClickBack : TraineeSignUpUiEvent
         data class RequestSignUp(
             val context: Context,
             val imageUri: Uri?,

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpScreen.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpScreen.kt
@@ -30,15 +30,15 @@ internal fun TraineeSignUpRoute(
 
     TraineeSignUpScreen(
         state = uiState,
-        onNameChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnNameChange(it)) },
-        onProfileImageSelect = { viewModel.setEvent(TraineeSignUpUiEvent.OnImageChange(it)) },
-        onHeightChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnHeightChange(it)) },
-        onWeightChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnWeightChange(it)) },
-        onBirthdayChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnBirthdayChange(it)) },
-        onPurposeSelected = { viewModel.setEvent(TraineeSignUpUiEvent.OnPurposeSelected(it)) },
-        onCautionChange = { viewModel.setEvent(TraineeSignUpUiEvent.OnCautionChange(it)) },
-        onBackClick = { viewModel.setEvent(TraineeSignUpUiEvent.OnBackClick) },
-        onNextClick = { viewModel.setEvent(TraineeSignUpUiEvent.OnNextClick) },
+        onChangeName = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeName(it)) },
+        onProfileImageSelect = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeImage(it)) },
+        onChangeHeight = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeHeight(it)) },
+        onChangeWeight = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeWeight(it)) },
+        onChangeBirthday = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeBirthday(it)) },
+        onSelectPurpose = { viewModel.setEvent(TraineeSignUpUiEvent.OnSelectPurpose(it)) },
+        onChangeCaution = { viewModel.setEvent(TraineeSignUpUiEvent.OnChangeCaution(it)) },
+        onClickBack = { viewModel.setEvent(TraineeSignUpUiEvent.OnClickBack) },
+        onClickNext = { viewModel.setEvent(TraineeSignUpUiEvent.OnClickNext) },
         onSubmitSignUp = { uri ->
             viewModel.setEvent(
                 TraineeSignUpUiEvent.RequestSignUp(
@@ -68,52 +68,52 @@ internal fun TraineeSignUpRoute(
 private fun TraineeSignUpScreen(
     state: TraineeSignUpUiState,
     onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
-    onHeightChange: (String) -> Unit,
-    onWeightChange: (String) -> Unit,
-    onCautionChange: (String) -> Unit,
-    onBirthdayChange: (LocalDate) -> Unit,
-    onPurposeSelected: (String) -> Unit,
+    onChangeName: (String) -> Unit,
+    onChangeHeight: (String) -> Unit,
+    onChangeWeight: (String) -> Unit,
+    onChangeCaution: (String) -> Unit,
+    onChangeBirthday: (LocalDate) -> Unit,
+    onSelectPurpose: (String) -> Unit,
     onSubmitSignUp: (Uri?) -> Unit,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickNext: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
     when (state.page) {
         TraineeSignUpPage.ProfileSetUp -> TraineeProfileSetupPage(
             state = state,
             onProfileImageSelect = onProfileImageSelect,
-            onNameChange = onNameChange,
-            onBackClick = onBackClick,
-            onNextClick = onNextClick,
+            onChangeName = onChangeName,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
 
         TraineeSignUpPage.BasicInfo -> TraineeBasicInfoPage(
             state = state,
-            onHeightChange = onHeightChange,
-            onWeightChange = onWeightChange,
-            onBirthdayChange = onBirthdayChange,
-            onBackClick = onBackClick,
-            onNextClick = onNextClick,
+            onChangeHeight = onChangeHeight,
+            onChangeWeight = onChangeWeight,
+            onChangeBirthday = onChangeBirthday,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
 
         TraineeSignUpPage.NoteForTrainer -> TraineeNoteForTrainerPage(
             caution = state.caution,
-            onCautionChange = onCautionChange,
-            onBackClick = onBackClick,
-            onNextClick = onNextClick,
+            onChangeCaution = onChangeCaution,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
 
         TraineeSignUpPage.PTPurpose -> TraineePTPurposePage(
             state = state,
-            onPurposeSelected = onPurposeSelected,
-            onBackClick = onBackClick,
-            onNextClick = onNextClick,
+            onSelectPurpose = onSelectPurpose,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
 
         TraineeSignUpPage.SignUpComplete -> TraineeSignUpCompletePage(
             state = state,
-            onBackClick = onBackClick,
-            onNextClick = onSubmitSignUp,
+            onClickBack = onClickBack,
+            onClickNext = onSubmitSignUp,
         )
     }
 }

--- a/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpViewModel.kt
+++ b/feature/trainee/signup/src/main/java/co/kr/tnt/trainee/signup/TraineeSignUpViewModel.kt
@@ -25,15 +25,15 @@ internal class TraineeSignUpViewModel @Inject constructor(
     ) {
     override suspend fun handleEvent(event: TraineeSignUpUiEvent) {
         when (event) {
-            is TraineeSignUpUiEvent.OnImageChange -> updateProfileImage(event.imageUri)
-            is TraineeSignUpUiEvent.OnNameChange -> updateName(event.name)
-            is TraineeSignUpUiEvent.OnHeightChange -> updateHeight(event.height)
-            is TraineeSignUpUiEvent.OnWeightChange -> updateWeight(event.weight)
-            is TraineeSignUpUiEvent.OnBirthdayChange -> updateBirthday(event.birthday)
-            is TraineeSignUpUiEvent.OnPurposeSelected -> updateSelectedPurposes(event.purpose)
-            is TraineeSignUpUiEvent.OnCautionChange -> updateCaution(event.text)
-            TraineeSignUpUiEvent.OnBackClick -> navigateToBack()
-            TraineeSignUpUiEvent.OnNextClick -> navigateToNext()
+            is TraineeSignUpUiEvent.OnChangeImage -> updateProfileImage(event.imageUri)
+            is TraineeSignUpUiEvent.OnChangeName -> updateName(event.name)
+            is TraineeSignUpUiEvent.OnChangeHeight -> updateHeight(event.height)
+            is TraineeSignUpUiEvent.OnChangeWeight -> updateWeight(event.weight)
+            is TraineeSignUpUiEvent.OnChangeBirthday -> updateBirthday(event.birthday)
+            is TraineeSignUpUiEvent.OnSelectPurpose -> updatePurposes(event.purpose)
+            is TraineeSignUpUiEvent.OnChangeCaution -> updateCaution(event.text)
+            TraineeSignUpUiEvent.OnClickBack -> navigateToBack()
+            TraineeSignUpUiEvent.OnClickNext -> navigateToNext()
             is TraineeSignUpUiEvent.RequestSignUp -> signUp(
                 context = event.context,
                 imageUri = event.imageUri,
@@ -108,7 +108,7 @@ internal class TraineeSignUpViewModel @Inject constructor(
         updateState { copy(birthday = birthday) }
     }
 
-    private fun updateSelectedPurposes(purpose: String) {
+    private fun updatePurposes(purpose: String) {
         val updatedPurposes = currentState.ptPurpose.orEmpty().toMutableList().apply {
             if (contains(purpose)) {
                 remove(purpose)

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TraineeProfilePage.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TraineeProfilePage.kt
@@ -49,10 +49,10 @@ import co.kr.tnt.core.ui.R as uiResource
 @Composable
 internal fun TraineeProfilePage(
     state: TrainerConnectUiState,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
     val trainee = state.traineeState
@@ -156,7 +156,7 @@ internal fun TraineeProfilePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -236,8 +236,8 @@ private fun TraineeProfilePagePreview() {
                     isConnected = true,
                 ),
             ),
-            onNextClick = {},
-            onBackClick = {},
+            onClickNext = {},
+            onClickBack = {},
         )
     }
 }

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectCompletePage.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectCompletePage.kt
@@ -40,10 +40,10 @@ import co.kr.tnt.core.ui.R as uiResource
 @Composable
 internal fun TrainerConnectCompletePage(
     state: TrainerConnectUiState,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
     val context = LocalContext.current
 
     Scaffold { innerPadding ->
@@ -97,7 +97,7 @@ internal fun TrainerConnectCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.next),
-                onClick = onNextClick,
+                onClick = onClickNext,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -146,8 +146,8 @@ private fun TrainerConnectCompletePagePreview() {
     TnTTheme {
         TrainerConnectCompletePage(
             state = TrainerConnectUiState(),
-            onNextClick = {},
-            onBackClick = {},
+            onClickNext = {},
+            onClickBack = {},
         )
     }
 }

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectContract.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectContract.kt
@@ -17,8 +17,8 @@ internal class TrainerConnectContract {
             val trainerId: String,
             val traineeId: String,
         ) : TrainerConnectUiEvent
-        data object OnNextClick : TrainerConnectUiEvent
-        data object OnBackClick : TrainerConnectUiEvent
+        data object OnClickNext : TrainerConnectUiEvent
+        data object OnClickBack : TrainerConnectUiEvent
     }
 
     sealed interface TrainerConnectSideEffect : UiSideEffect {

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectScreen.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectScreen.kt
@@ -28,8 +28,8 @@ internal fun TrainerConnectRoute(
 
     TrainerConnectScreen(
         state = state,
-        onBackClick = { viewModel.setEvent(TrainerConnectUiEvent.OnBackClick) },
-        onNextClick = { viewModel.setEvent(TrainerConnectUiEvent.OnNextClick) },
+        onClickBack = { viewModel.setEvent(TrainerConnectUiEvent.OnClickBack) },
+        onClickNext = { viewModel.setEvent(TrainerConnectUiEvent.OnClickNext) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -46,20 +46,20 @@ internal fun TrainerConnectRoute(
 @Composable
 private fun TrainerConnectScreen(
     state: TrainerConnectUiState,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
     when (state.page) {
         TrainerConnectPage.TrainerConnectComplete -> TrainerConnectCompletePage(
             state = state,
-            onBackClick = onBackClick,
-            onNextClick = onNextClick,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
 
         TrainerConnectPage.TraineeProfile -> TraineeProfilePage(
             state = state,
-            onNextClick = onNextClick,
-            onBackClick = onBackClick,
+            onClickBack = onClickBack,
+            onClickNext = onClickNext,
         )
     }
 }

--- a/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectViewModel.kt
+++ b/feature/trainer/connect/src/main/java/co/kr/tnt/trainer/connect/TrainerConnectViewModel.kt
@@ -26,8 +26,8 @@ internal class TrainerConnectViewModel @Inject constructor(
                 event.traineeId,
             )
 
-            TrainerConnectUiEvent.OnNextClick -> navigateToNext()
-            TrainerConnectUiEvent.OnBackClick -> navigateToBack()
+            TrainerConnectUiEvent.OnClickNext -> navigateToNext()
+            TrainerConnectUiEvent.OnClickBack -> navigateToBack()
         }
     }
 

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -114,7 +114,7 @@ internal fun TrainerHomeRoute(
                 rightButtonText = stringResource(coreR.string.connect),
                 onLeftButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
                 onRightButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnConfirmConnectDialog) },
-                onCheckClick = { viewModel.setEvent(TrainerHomeUiEvent.OnChangeHideDialogOption) },
+                onClickCheck = { viewModel.setEvent(TrainerHomeUiEvent.OnChangeHideDialogOption) },
                 onDismiss = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
             )
         }

--- a/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteContract.kt
+++ b/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteContract.kt
@@ -10,10 +10,10 @@ internal class TrainerInviteContract {
     ) : UiState
 
     sealed interface TrainerInviteUiEvent : UiEvent {
-        data object OnRegenerateClick : TrainerInviteUiEvent
-        data class OnCodeClick(val code: String) : TrainerInviteUiEvent
-        data object OnBackClick : TrainerInviteUiEvent
-        data object OnSkipClick : TrainerInviteUiEvent
+        data object OnClickRegenerate : TrainerInviteUiEvent
+        data class OnClickCode(val code: String) : TrainerInviteUiEvent
+        data object OnClickBack : TrainerInviteUiEvent
+        data object OnClickSkip : TrainerInviteUiEvent
     }
 
     sealed interface TrainerInviteSideEffect : UiSideEffect {

--- a/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteScreen.kt
+++ b/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteScreen.kt
@@ -57,10 +57,10 @@ internal fun TrainerInviteRoute(
     TrainerInviteScreen(
         state = state,
         screenMode = screenMode,
-        onRegenerateClick = { viewModel.setEvent(TrainerInviteUiEvent.OnRegenerateClick) },
-        onCodeClick = { code -> viewModel.setEvent(TrainerInviteUiEvent.OnCodeClick(code)) },
-        onBackClick = { viewModel.setEvent(TrainerInviteUiEvent.OnBackClick) },
-        onSkipClick = { viewModel.setEvent(TrainerInviteUiEvent.OnSkipClick) },
+        onClickRegenerate = { viewModel.setEvent(TrainerInviteUiEvent.OnClickRegenerate) },
+        onClickCode = { code -> viewModel.setEvent(TrainerInviteUiEvent.OnClickCode(code)) },
+        onClickBack = { viewModel.setEvent(TrainerInviteUiEvent.OnClickBack) },
+        onClickSkip = { viewModel.setEvent(TrainerInviteUiEvent.OnClickSkip) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -80,16 +80,16 @@ internal fun TrainerInviteRoute(
 internal fun TrainerInviteScreen(
     state: TrainerInviteUiState,
     screenMode: ScreenMode,
-    onCodeClick: (code: String) -> Unit,
-    onRegenerateClick: () -> Unit,
-    onBackClick: () -> Unit,
-    onSkipClick: () -> Unit,
+    onClickCode: (code: String) -> Unit,
+    onClickRegenerate: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickSkip: () -> Unit,
 ) {
     BackHandler {
         when (screenMode) {
-            ScreenMode.BACK -> onBackClick()
-            ScreenMode.SKIP -> onSkipClick()
-            ScreenMode.CLOSE -> onBackClick()
+            ScreenMode.BACK -> onClickBack()
+            ScreenMode.SKIP -> onClickSkip()
+            ScreenMode.CLOSE -> onClickBack()
         }
     }
 
@@ -99,7 +99,7 @@ internal fun TrainerInviteScreen(
                 ScreenMode.BACK -> {
                     TnTTopBarWithBackButton(
                         title = stringResource(R.string.add_member),
-                        onBackClick = onBackClick,
+                        onBackClick = onClickBack,
                     )
                 }
 
@@ -112,7 +112,7 @@ internal fun TrainerInviteScreen(
                                 color = TnTTheme.colors.neutralColors.Neutral400,
                                 style = TnTTheme.typography.body2Medium,
                                 modifier = Modifier.clickable {
-                                    onSkipClick()
+                                    onClickSkip()
                                 },
                             )
                         },
@@ -124,7 +124,7 @@ internal fun TrainerInviteScreen(
                         title = stringResource(R.string.add_member),
                         trailingComponent = {
                             IconButton(
-                                onClick = onBackClick,
+                                onClick = onClickBack,
                             ) {
                                 Icon(
                                     painter = painterResource(co.kr.tnt.core.designsystem.R.drawable.ic_delete),
@@ -172,7 +172,7 @@ internal fun TrainerInviteScreen(
                                 color = TnTTheme.colors.neutralColors.Neutral600,
                                 modifier = Modifier
                                     .padding(8.dp)
-                                    .clickable { onCodeClick(state.inviteCode) },
+                                    .clickable { onClickCode(state.inviteCode) },
                             )
                             HorizontalDivider(
                                 thickness = 1.dp,
@@ -190,7 +190,7 @@ internal fun TrainerInviteScreen(
                                     text = stringResource(R.string.code_reissue),
                                     size = ButtonSize.Small,
                                     type = ButtonType.Gray,
-                                    onClick = { onRegenerateClick() },
+                                    onClick = { onClickRegenerate() },
                                 )
                             },
                         )
@@ -207,10 +207,10 @@ private fun CodeGenerationPagePreview() {
     TnTTheme {
         TrainerInviteScreen(
             state = TrainerInviteUiState(),
-            onCodeClick = {},
-            onBackClick = {},
-            onSkipClick = {},
-            onRegenerateClick = {},
+            onClickCode = {},
+            onClickBack = {},
+            onClickSkip = {},
+            onClickRegenerate = {},
             screenMode = ScreenMode.SKIP,
         )
     }

--- a/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteViewModel.kt
+++ b/feature/trainer/invite/src/main/java/co/kr/tnt/trainer/invite/TrainerInviteViewModel.kt
@@ -18,11 +18,10 @@ internal class TrainerInviteViewModel @Inject constructor(
     ) {
     override suspend fun handleEvent(event: TrainerInviteUiEvent) {
         when (event) {
-            TrainerInviteUiEvent.OnRegenerateClick -> regenerateCode()
-            TrainerInviteUiEvent.OnRegenerateClick -> generateCode()
-            TrainerInviteUiEvent.OnBackClick -> navigateToBack()
-            TrainerInviteUiEvent.OnSkipClick -> navigateToHome()
-            is TrainerInviteUiEvent.OnCodeClick -> {
+            TrainerInviteUiEvent.OnClickRegenerate -> regenerateCode()
+            TrainerInviteUiEvent.OnClickBack -> navigateToBack()
+            TrainerInviteUiEvent.OnClickSkip -> navigateToHome()
+            is TrainerInviteUiEvent.OnClickCode -> {
                 sendEffect(TrainerInviteSideEffect.CopyToClipBoard(event.code))
                 sendEffect(TrainerInviteSideEffect.ShowToast("코드가 복사되었어요!"))
             }
@@ -40,7 +39,6 @@ internal class TrainerInviteViewModel @Inject constructor(
             }.onSuccess { result ->
                 updateState { copy(inviteCode = result.invitationCode) }
             }.onFailure {
-                // TODO 컴포넌트 사용
                 sendEffect(TrainerInviteSideEffect.ShowToast("서버 요청에 실패했어요"))
             }
         }
@@ -53,7 +51,6 @@ internal class TrainerInviteViewModel @Inject constructor(
             }.onSuccess { result ->
                 updateState { copy(inviteCode = result.invitationCode) }
             }.onFailure {
-                // TODO 컴포넌트 사용
                 sendEffect(TrainerInviteSideEffect.ShowToast("서버 요청에 실패했어요"))
             }
         }

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationContract.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationContract.kt
@@ -14,7 +14,7 @@ internal class TrainerNotificationContract {
 
     sealed interface TrainerNotificationUiEvent : UiEvent {
         data object OnClickBack : TrainerNotificationUiEvent
-        data object OnLinkNotificationClick : TrainerNotificationUiEvent
+        data object OnClickConnectionNotice : TrainerNotificationUiEvent
     }
 
     sealed interface TrainerNotificationEffect : UiSideEffect {

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationContract.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationContract.kt
@@ -13,7 +13,7 @@ internal class TrainerNotificationContract {
     ) : UiState
 
     sealed interface TrainerNotificationUiEvent : UiEvent {
-        data object OnBackClick : TrainerNotificationUiEvent
+        data object OnClickBack : TrainerNotificationUiEvent
         data object OnLinkNotificationClick : TrainerNotificationUiEvent
     }
 

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationScreen.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationScreen.kt
@@ -40,7 +40,7 @@ internal fun TrainerNotificationRoute(
     TrainerNotificationScreen(
         state = uiState,
         onClickBack = { viewModel.setEvent(TrainerNotificationUiEvent.OnClickBack) },
-        onLinkNotificationClick = { viewModel.setEvent(TrainerNotificationUiEvent.OnLinkNotificationClick) },
+        onClickConnectionNotice = { viewModel.setEvent(TrainerNotificationUiEvent.OnClickConnectionNotice) },
     )
 
     LaunchedEffect(viewModel.effect) {
@@ -62,7 +62,7 @@ internal fun TrainerNotificationRoute(
 private fun TrainerNotificationScreen(
     state: TrainerNotificationUiState,
     onClickBack: () -> Unit,
-    onLinkNotificationClick: () -> Unit,
+    onClickConnectionNotice: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -102,7 +102,7 @@ private fun TrainerNotificationScreen(
                             time = notification.time,
                             isChecked = notification.isChecked,
                             onClick = if (notification.isClickable) {
-                                onLinkNotificationClick
+                                onClickConnectionNotice
                             } else {
                                 null
                             },
@@ -143,7 +143,7 @@ private fun TrainerNotificationScreenPreview() {
         )
         TrainerNotificationScreen(
             onClickBack = {},
-            onLinkNotificationClick = {},
+            onClickConnectionNotice = {},
             state = TrainerNotificationUiState(notifications = sampleNotifications),
         )
     }

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationScreen.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationScreen.kt
@@ -39,7 +39,7 @@ internal fun TrainerNotificationRoute(
 
     TrainerNotificationScreen(
         state = uiState,
-        onBackClick = { viewModel.setEvent(TrainerNotificationUiEvent.OnBackClick) },
+        onClickBack = { viewModel.setEvent(TrainerNotificationUiEvent.OnClickBack) },
         onLinkNotificationClick = { viewModel.setEvent(TrainerNotificationUiEvent.OnLinkNotificationClick) },
     )
 
@@ -61,14 +61,14 @@ internal fun TrainerNotificationRoute(
 @Composable
 private fun TrainerNotificationScreen(
     state: TrainerNotificationUiState,
-    onBackClick: () -> Unit,
+    onClickBack: () -> Unit,
     onLinkNotificationClick: () -> Unit,
 ) {
     Scaffold(
         topBar = {
             TnTTopBarWithBackButton(
                 title = stringResource(uiResource.string.notification),
-                onBackClick = onBackClick,
+                onBackClick = onClickBack,
                 showStoke = true,
             )
         },
@@ -142,7 +142,7 @@ private fun TrainerNotificationScreenPreview() {
             ),
         )
         TrainerNotificationScreen(
-            onBackClick = {},
+            onClickBack = {},
             onLinkNotificationClick = {},
             state = TrainerNotificationUiState(notifications = sampleNotifications),
         )

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationViewModel.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationViewModel.kt
@@ -20,7 +20,7 @@ internal class TrainerNotificationViewModel @Inject constructor() :
 
         override suspend fun handleEvent(event: TrainerNotificationUiEvent) {
             when (event) {
-                TrainerNotificationUiEvent.OnBackClick -> navigateToBack()
+                TrainerNotificationUiEvent.OnClickBack -> navigateToBack()
                 TrainerNotificationUiEvent.OnLinkNotificationClick -> navigateToConnect()
             }
         }

--- a/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationViewModel.kt
+++ b/feature/trainer/notification/src/main/java/co/kr/tnt/trainer/notification/TrainerNotificationViewModel.kt
@@ -21,7 +21,7 @@ internal class TrainerNotificationViewModel @Inject constructor() :
         override suspend fun handleEvent(event: TrainerNotificationUiEvent) {
             when (event) {
                 TrainerNotificationUiEvent.OnClickBack -> navigateToBack()
-                TrainerNotificationUiEvent.OnLinkNotificationClick -> navigateToConnect()
+                TrainerNotificationUiEvent.OnClickConnectionNotice -> navigateToConnect()
             }
         }
 

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupPage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerProfileSetupPage.kt
@@ -45,18 +45,18 @@ private const val MAX_LENGTH = 15
 @Composable
 internal fun TrainerProfileSetupPage(
     state: TrainerSignUpUiState,
-    onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
-    onBackClick: () -> Unit,
-    onNextClick: () -> Unit,
+    onSelectProfileImage: (Uri) -> Unit,
+    onChangeName: (String) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: () -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
 
     val pickMediaLauncher = rememberLauncherForActivityResult(PickVisualMedia()) { uri ->
         if (uri != null) {
-            onProfileImageSelect(uri)
+            onSelectProfileImage(uri)
         }
     }
     val painter = rememberAsyncImagePainter(
@@ -67,7 +67,7 @@ internal fun TrainerProfileSetupPage(
     )
 
     Scaffold(
-        topBar = { TnTTopBarWithBackButton(onBackClick = onBackClick) },
+        topBar = { TnTTopBarWithBackButton(onBackClick = onClickBack) },
         containerColor = TnTTheme.colors.commonColors.Common0,
         modifier = Modifier.clearFocusOnTap(),
     ) { innerPadding ->
@@ -105,7 +105,7 @@ internal fun TrainerProfileSetupPage(
                     title = stringResource(coreR.string.name),
                     value = state.name,
                     onValueChange = { newValue ->
-                        onNameChange(newValue)
+                        onChangeName(newValue)
                     },
                     modifier = Modifier.padding(horizontal = 20.dp),
                     placeholder = stringResource(R.string.name_placeholder),
@@ -120,7 +120,7 @@ internal fun TrainerProfileSetupPage(
                 text = stringResource(coreR.string.next),
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = state.name.isNotBlank() && state.isNameValid,
-                onClick = onNextClick,
+                onClick = onClickNext,
             )
         }
     }
@@ -132,10 +132,10 @@ private fun TrainerProfileSetupPagePreview() {
     TnTTheme {
         TrainerProfileSetupPage(
             state = TrainerSignUpUiState(),
-            onNameChange = {},
-            onProfileImageSelect = {},
-            onBackClick = {},
-            onNextClick = {},
+            onChangeName = {},
+            onSelectProfileImage = {},
+            onClickBack = {},
+            onClickNext = {},
         )
     }
 }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpCompletePage.kt
@@ -33,10 +33,10 @@ import co.kr.tnt.core.ui.R as uiResource
 @Composable
 internal fun TrainerSignUpCompletePage(
     state: TrainerSignUpUiState,
-    onBackClick: () -> Unit,
-    onNextClick: (Uri?) -> Unit,
+    onClickBack: () -> Unit,
+    onClickNext: (Uri?) -> Unit,
 ) {
-    BackHandler { onBackClick() }
+    BackHandler { onClickBack() }
 
     Scaffold(
         containerColor = TnTTheme.colors.commonColors.Common0,
@@ -79,7 +79,7 @@ internal fun TrainerSignUpCompletePage(
             }
             TnTBottomButton(
                 text = stringResource(uiResource.string.start),
-                onClick = throttled { onNextClick(state.image) },
+                onClick = throttled { onClickNext(state.image) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -95,8 +95,8 @@ internal fun TrainerSignUpCompletePage(
 private fun TrainerSignUpCompletePagePreview() {
     TnTTheme {
         TrainerSignUpCompletePage(
-            onBackClick = {},
-            onNextClick = {},
+            onClickBack = {},
+            onClickNext = {},
             state = TrainerSignUpUiState(),
         )
     }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpContract.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpContract.kt
@@ -23,10 +23,10 @@ internal class TrainerSignUpContract {
     }
 
     sealed interface TrainerSignUpUiEvent : UiEvent {
-        data class OnImageChange(val imageUri: Uri) : TrainerSignUpUiEvent
-        data class OnNameChange(val name: String) : TrainerSignUpUiEvent
-        data object OnNextClick : TrainerSignUpUiEvent
-        data object OnBackClick : TrainerSignUpUiEvent
+        data class OnChangeImage(val imageUri: Uri) : TrainerSignUpUiEvent
+        data class OnChangeName(val name: String) : TrainerSignUpUiEvent
+        data object OnClickNext : TrainerSignUpUiEvent
+        data object OnClickBack : TrainerSignUpUiEvent
         data class RequestSignUp(
             val context: Context,
             val imageUri: Uri?,

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpScreen.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpScreen.kt
@@ -28,10 +28,10 @@ internal fun TrainerSignUpRoute(
 
     TrainerSignUpScreen(
         state = uiState,
-        onNameChange = { viewModel.setEvent(TrainerSignUpUiEvent.OnNameChange(it)) },
-        onProfileImageSelect = { viewModel.setEvent(TrainerSignUpUiEvent.OnImageChange(it)) },
-        onNextClick = { viewModel.setEvent(TrainerSignUpUiEvent.OnNextClick) },
-        onBackClick = { viewModel.setEvent(TrainerSignUpUiEvent.OnBackClick) },
+        onChangeName = { viewModel.setEvent(TrainerSignUpUiEvent.OnChangeName(it)) },
+        onSelectProfileImage = { viewModel.setEvent(TrainerSignUpUiEvent.OnChangeImage(it)) },
+        onClickNext = { viewModel.setEvent(TrainerSignUpUiEvent.OnClickNext) },
+        onClickBack = { viewModel.setEvent(TrainerSignUpUiEvent.OnClickBack) },
         onSubmitSignUp = { uri ->
             viewModel.setEvent(
                 TrainerSignUpUiEvent.RequestSignUp(
@@ -60,25 +60,25 @@ internal fun TrainerSignUpRoute(
 @Composable
 private fun TrainerSignUpScreen(
     state: TrainerSignUpUiState,
-    onProfileImageSelect: (Uri) -> Unit,
-    onNameChange: (String) -> Unit,
+    onSelectProfileImage: (Uri) -> Unit,
+    onChangeName: (String) -> Unit,
     onSubmitSignUp: (Uri?) -> Unit,
-    onNextClick: () -> Unit,
-    onBackClick: () -> Unit,
+    onClickNext: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
     when (state.page) {
         TrainerSignUpContract.TrainerSignUpPage.ProfileSetUp -> TrainerProfileSetupPage(
             state = state,
-            onProfileImageSelect = onProfileImageSelect,
-            onNameChange = onNameChange,
-            onNextClick = onNextClick,
-            onBackClick = onBackClick,
+            onSelectProfileImage = onSelectProfileImage,
+            onChangeName = onChangeName,
+            onClickNext = onClickNext,
+            onClickBack = onClickBack,
         )
 
         TrainerSignUpContract.TrainerSignUpPage.SignUpComplete -> TrainerSignUpCompletePage(
             state = state,
-            onNextClick = onSubmitSignUp,
-            onBackClick = onBackClick,
+            onClickNext = onSubmitSignUp,
+            onClickBack = onClickBack,
         )
     }
 }

--- a/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
+++ b/feature/trainer/signup/src/main/java/co/kr/tnt/trainer/signup/TrainerSignUpViewModel.kt
@@ -26,10 +26,10 @@ internal class TrainerSignUpViewModel @Inject constructor(
     ) {
     override suspend fun handleEvent(event: TrainerSignUpUiEvent) {
         when (event) {
-            is TrainerSignUpUiEvent.OnImageChange -> setProfileImage(event.imageUri)
-            is TrainerSignUpUiEvent.OnNameChange -> setName(event.name)
-            TrainerSignUpUiEvent.OnNextClick -> navigateToNext()
-            TrainerSignUpUiEvent.OnBackClick -> navigateToBack()
+            is TrainerSignUpUiEvent.OnChangeImage -> setProfileImage(event.imageUri)
+            is TrainerSignUpUiEvent.OnChangeName -> setName(event.name)
+            TrainerSignUpUiEvent.OnClickNext -> navigateToNext()
+            TrainerSignUpUiEvent.OnClickBack -> navigateToBack()
             is TrainerSignUpUiEvent.RequestSignUp -> signUp(
                 context = event.context,
                 imageUri = event.imageUri,

--- a/feature/webview/src/main/java/co/kr/tnt/webview/WebViewNavigation.kt
+++ b/feature/webview/src/main/java/co/kr/tnt/webview/WebViewNavigation.kt
@@ -22,7 +22,7 @@ fun NavGraphBuilder.webViewScreen(
         backstackEntry.toRoute<Route.WebView>().apply {
             WebViewScreen(
                 url = url,
-                onBackClick = navigateToPrevious,
+                onClickBack = navigateToPrevious,
             )
         }
     }

--- a/feature/webview/src/main/java/co/kr/tnt/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/co/kr/tnt/webview/WebViewScreen.kt
@@ -16,7 +16,7 @@ import co.kr.tnt.designsystem.theme.TnTTheme
 @Composable
 internal fun WebViewScreen(
     url: String,
-    onBackClick: () -> Unit,
+    onClickBack: () -> Unit,
 ) {
     var webView: WebView? = null
 
@@ -24,7 +24,7 @@ internal fun WebViewScreen(
         if (webView?.canGoBack() == true) {
             webView?.goBack()
         } else {
-            onBackClick()
+            onClickBack()
         }
     }
 


### PR DESCRIPTION
## 📝 작업 내용

- Closes #136 

- Composable 함수의 파라미터와 uiState 관련 네이밍을 정호님 코드 스타일에 맞춰 통일했습니다.
- 기존의 **on[명사][동사]** 방식에서 **on[동사][명사]** 방식으로 수정했습니다.
  - 예: `onNameChange` ➡️  `onChangeName`
- 클릭 동작들의 경우 `onClick + 대상` 으로 통일했습니다.

## 📸 실행 화면
- UI 변경사항 없습니다



## 🙆🏻 리뷰 요청 사항



## 👀 레퍼런스

