### PR TITLE
[TNT-307] 트레이너 주간 캘린더 전환 및 수업 완료 시간 검증 추가

### DIFF
--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeContract.kt
@@ -14,15 +14,9 @@ internal class TrainerHomeContract {
         val selectedDay: LocalDate = LocalDate.now(),
         val dailyPtSessionCount: Map<LocalDate, Int> = mapOf(),
         val selectedDayPtSessions: List<PtSession>? = null,
-        val dialogState: DialogState = DialogState.NONE,
+        val dialogState: TrainerHomeDialog = TrainerHomeDialog.None,
         val isDialogHiddenForThreeDays: Boolean = false,
-    ) : UiState {
-        enum class DialogState {
-            NONE,
-            HOME_CONNECT,
-            ADD_PT_CONNECT,
-        }
-    }
+    ) : UiState
 
     sealed interface TrainerHomeUiEvent : UiEvent {
         data object OnScreen : TrainerHomeUiEvent
@@ -32,6 +26,7 @@ internal class TrainerHomeContract {
         data object OnClickAddPtSession : TrainerHomeUiEvent
         data class OnClickPtSessionComplete(val ptSession: PtSession) : TrainerHomeUiEvent
         data object OnConfirmConnectDialog : TrainerHomeUiEvent
+        data class OnConfirmEarlyPtCompletion(val ptSession: PtSession) : TrainerHomeUiEvent
         data object OnChangeHideDialogOption : TrainerHomeUiEvent
         data object OnDismissDialog : TrainerHomeUiEvent
     }
@@ -44,5 +39,12 @@ internal class TrainerHomeContract {
             val message: DisplayText,
             val type: SnackbarType = SnackbarType.WARNING,
         ) : TrainerHomeSideEffect
+    }
+
+    sealed interface TrainerHomeDialog {
+        data object None : TrainerHomeDialog
+        data object HomeConnect : TrainerHomeDialog
+        data object AddPtConnect : TrainerHomeDialog
+        data class EarlyPtCompletion(val ptSession: PtSession) : TrainerHomeDialog
     }
 }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -42,9 +42,12 @@ import co.kr.tnt.core.designsystem.R.drawable.ic_add
 import co.kr.tnt.core.designsystem.R.drawable.ic_fill_check_false
 import co.kr.tnt.core.designsystem.R.drawable.ic_fill_check_true
 import co.kr.tnt.core.designsystem.R.drawable.img_default
+import co.kr.tnt.core.ui.R.string.core_cancel
 import co.kr.tnt.core.ui.R.string.core_connect
 import co.kr.tnt.core.ui.R.string.core_do_not_see_for_three_days
 import co.kr.tnt.core.ui.R.string.core_next_time
+import co.kr.tnt.core.ui.R.string.core_ok
+import co.kr.tnt.designsystem.component.TnTIconPopupDialog
 import co.kr.tnt.designsystem.component.TnTPopupDialog
 import co.kr.tnt.designsystem.component.button.TnTFabButton
 import co.kr.tnt.designsystem.component.calendar.TnTIndicatorWeekCalendar
@@ -58,6 +61,7 @@ import co.kr.tnt.domain.model.PtSession
 import co.kr.tnt.domain.utils.DateFormatter
 import co.kr.tnt.feature.trainer.home.R
 import co.kr.tnt.navigation.model.ScreenMode
+import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeDialog
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeSideEffect
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiEvent
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState
@@ -109,9 +113,9 @@ internal fun TrainerHomeRoute(
         }
     }
 
-    when (state.dialogState) {
-        TrainerHomeUiState.DialogState.NONE -> Unit
-        TrainerHomeUiState.DialogState.HOME_CONNECT -> {
+    when (val dialogState = state.dialogState) {
+        TrainerHomeDialog.None -> Unit
+        TrainerHomeDialog.HomeConnect -> {
             TnTCheckToggleDialog(
                 title = stringResource(R.string.please_connect_member),
                 content = stringResource(R.string.cannot_add_pt_without_connection),
@@ -126,7 +130,7 @@ internal fun TrainerHomeRoute(
             )
         }
 
-        TrainerHomeUiState.DialogState.ADD_PT_CONNECT -> {
+        TrainerHomeDialog.AddPtConnect -> {
             TnTPopupDialog(
                 title = stringResource(R.string.please_connect_member),
                 content = stringResource(R.string.cannot_add_pt_without_connection),
@@ -134,6 +138,22 @@ internal fun TrainerHomeRoute(
                 rightButtonText = stringResource(core_connect),
                 onLeftButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
                 onRightButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnConfirmConnectDialog) },
+                onDismiss = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+            )
+        }
+
+        is TrainerHomeDialog.EarlyPtCompletion -> {
+            TnTIconPopupDialog(
+                title = stringResource(R.string.pt_early_completion_title),
+                content = stringResource(R.string.pt_early_completion_message),
+                leftButtonText = stringResource(core_cancel),
+                rightButtonText = stringResource(core_ok),
+                onLeftButtonClick = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
+                onRightButtonClick = {
+                    viewModel.setEvent(
+                        TrainerHomeUiEvent.OnConfirmEarlyPtCompletion(dialogState.ptSession),
+                    )
+                },
                 onDismiss = { viewModel.setEvent(TrainerHomeUiEvent.OnDismissDialog) },
             )
         }

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeScreen.kt
@@ -47,10 +47,10 @@ import co.kr.tnt.core.ui.R.string.core_do_not_see_for_three_days
 import co.kr.tnt.core.ui.R.string.core_next_time
 import co.kr.tnt.designsystem.component.TnTPopupDialog
 import co.kr.tnt.designsystem.component.button.TnTFabButton
-import co.kr.tnt.designsystem.component.calendar.TnTIndicatorMonthCalendar
+import co.kr.tnt.designsystem.component.calendar.TnTIndicatorWeekCalendar
 import co.kr.tnt.designsystem.component.calendar.model.DayIndicatorState
 import co.kr.tnt.designsystem.component.calendar.model.DayState
-import co.kr.tnt.designsystem.component.calendar.utils.rememberMostVisibleMonth
+import co.kr.tnt.designsystem.component.calendar.utils.rememberMostVisibleYearMonth
 import co.kr.tnt.designsystem.component.card.TnTSessionRecordCard
 import co.kr.tnt.designsystem.snackbar.LocalSnackbar
 import co.kr.tnt.designsystem.theme.TnTTheme
@@ -66,8 +66,8 @@ import co.kr.tnt.ui.component.TnTHomeTopBar
 import co.kr.tnt.ui.utils.throttled
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
-import com.kizitonwose.calendar.compose.CalendarState
-import com.kizitonwose.calendar.compose.rememberCalendarState
+import com.kizitonwose.calendar.compose.weekcalendar.WeekCalendarState
+import com.kizitonwose.calendar.compose.weekcalendar.rememberWeekCalendarState
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -153,15 +153,14 @@ private fun TrainerHomeScreen(
     onClickAddPtSession: () -> Unit,
     onClickPtSessionComplete: (PtSession) -> Unit,
 ) {
-    val now = remember { YearMonth.now() }
-    val calendarState = rememberCalendarState(
-        firstVisibleMonth = now,
+    val weekCalendarState = rememberWeekCalendarState(
         firstDayOfWeek = DayOfWeek.SUNDAY,
-        startMonth = now.minusYears(10),
-        endMonth = now.plusYears(10),
+        firstVisibleWeekDate = state.selectedDay,
+        startDate = state.selectedDay.minusYears(10),
+        endDate = state.selectedDay.plusYears(10),
     )
     val coroutineScope = rememberCoroutineScope()
-    val visibleMonth = rememberMostVisibleMonth(calendarState)
+    var visibleMonth = rememberMostVisibleYearMonth(weekCalendarState)
     val dateFormatter = remember { DateFormatter() }
 
     Box(modifier = Modifier.padding(padding)) {
@@ -181,27 +180,32 @@ private fun TrainerHomeScreen(
                         onClickNotification = onClickNotification,
                         onClickSelectorPrevious = {
                             coroutineScope.launch {
-                                calendarState.animateScrollToMonth(visibleMonth.minusMonths(1))
+                                val previousWeek = weekCalendarState.firstVisibleWeek.days.first().date.minusWeeks(1)
+                                visibleMonth = YearMonth.from(previousWeek)
+                                weekCalendarState.animateScrollToWeek(previousWeek)
                             }
                         },
                         onClickSelectorNext = {
                             coroutineScope.launch {
-                                calendarState.animateScrollToMonth(visibleMonth.plusMonths(1))
+                                val nextWeek =
+                                    weekCalendarState.firstVisibleWeek.days.first().date.plusWeeks(1)
+                                visibleMonth = YearMonth.from(nextWeek)
+                                weekCalendarState.animateScrollToWeek(nextWeek)
                             }
                         },
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     Calendar(
                         modifier = Modifier.background(color = TnTTheme.colors.commonColors.Common0),
-                        calendarState = calendarState,
+                        weekCalendarState = weekCalendarState,
                         selectedDay = state.selectedDay,
                         dailyPtSessionCount = state.dailyPtSessionCount,
                         onClickDay = onClickDay,
                     )
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
                 }
                 Column {
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(20.dp))
                     DailyPtSessionTitle(
                         day = state.selectedDay,
                         sessionCount = state.selectedDayPtSessions?.size ?: 0,
@@ -253,16 +257,14 @@ private fun TrainerHomeScreen(
 
 @Composable
 private fun Calendar(
-    calendarState: CalendarState,
+    weekCalendarState: WeekCalendarState,
     selectedDay: LocalDate,
     dailyPtSessionCount: Map<LocalDate, Int>,
     onClickDay: (date: LocalDate) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    TnTIndicatorMonthCalendar(
-        modifier = modifier,
-        state = calendarState,
-        onClickDay = onClickDay,
+    TnTIndicatorWeekCalendar(
+        state = weekCalendarState,
         dayState = { day -> DayState(isSelected = day == selectedDay) },
         indicatorState = { day ->
             val count = dailyPtSessionCount[day] ?: 0
@@ -273,6 +275,8 @@ private fun Calendar(
                 showText = count != 0,
             )
         },
+        onClickDay = onClickDay,
+        modifier = modifier.background(TnTTheme.colors.commonColors.Common0),
     )
 }
 

--- a/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
+++ b/feature/trainer/home/src/main/java/co/kr/tnt/trainer/home/TrainerHomeViewModel.kt
@@ -7,10 +7,10 @@ import co.kr.tnt.domain.model.trainer.TrainerDailyPtSessionCount
 import co.kr.tnt.domain.repository.ConnectRepository
 import co.kr.tnt.domain.repository.TrainerRepository
 import co.kr.tnt.feature.trainer.home.R
+import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeDialog
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeSideEffect
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiEvent
 import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState
-import co.kr.tnt.trainer.home.TrainerHomeContract.TrainerHomeUiState.DialogState
 import co.kr.tnt.ui.base.BaseViewModel
 import co.kr.tnt.ui.model.SnackbarType
 import co.kr.tnt.ui.resource.DisplayText
@@ -51,8 +51,11 @@ internal class TrainerHomeViewModel @Inject constructor(
                 is TrainerHomeUiEvent.OnChangeVisibleMonth -> getMonthlySessionCounts(event.yearMonth)
                 is TrainerHomeUiEvent.OnClickDay -> selectDay(event.day)
                 TrainerHomeUiEvent.OnClickAddPtSession -> showConnectDialog(false)
-
-                is TrainerHomeUiEvent.OnClickPtSessionComplete -> completePtSession(event.ptSession)
+                is TrainerHomeUiEvent.OnClickPtSessionComplete -> completePtSessionIfStartTimeBeforeNow(event.ptSession)
+                is TrainerHomeUiEvent.OnConfirmEarlyPtCompletion -> {
+                    completePtSession(event.ptSession)
+                    updateState { copy(dialogState = TrainerHomeDialog.None) }
+                }
                 TrainerHomeUiEvent.OnChangeHideDialogOption -> toggleDialogHiddenState()
                 TrainerHomeUiEvent.OnConfirmConnectDialog -> handleDialogConfirm()
                 TrainerHomeUiEvent.OnDismissDialog -> dismissDialog()
@@ -123,6 +126,15 @@ internal class TrainerHomeViewModel @Inject constructor(
             updateState { copy(dailyPtSessionCount = updatedDailyPtSessionCount) }
         }
 
+        private fun completePtSessionIfStartTimeBeforeNow(ptSession: PtSession) {
+            if (LocalDateTime.now().isBefore(ptSession.startTime)) {
+                updateState { copy(dialogState = TrainerHomeDialog.EarlyPtCompletion(ptSession)) }
+                return
+            }
+
+            completePtSession(ptSession)
+        }
+
         private fun completePtSession(ptSession: PtSession) {
             viewModelScope.launch {
                 runCatching {
@@ -178,7 +190,7 @@ internal class TrainerHomeViewModel @Inject constructor(
                     trainerRepository.getActiveMembers()
                 }.onSuccess { result ->
                     if (result.isNotEmpty()) {
-                        updateState { copy(dialogState = DialogState.NONE) }
+                        updateState { copy(dialogState = TrainerHomeDialog.None) }
                         if (triggeredByHome.not()) {
                             sendEffect(TrainerHomeSideEffect.NavigateToAddPtSession)
                         }
@@ -191,9 +203,9 @@ internal class TrainerHomeViewModel @Inject constructor(
                     Duration.between(lastHiddenDate, currentDateTime).toHours() < DIALOG_HIDE_DURATION_HOURS
 
                 if (isHidden.not() && triggeredByHome) {
-                    updateState { copy(dialogState = DialogState.HOME_CONNECT) }
+                    updateState { copy(dialogState = TrainerHomeDialog.HomeConnect) }
                 } else if (triggeredByHome.not()) {
-                    updateState { copy(dialogState = DialogState.ADD_PT_CONNECT) }
+                    updateState { copy(dialogState = TrainerHomeDialog.AddPtConnect) }
                 }
             }
         }
@@ -207,12 +219,15 @@ internal class TrainerHomeViewModel @Inject constructor(
                 updateCurrentDateTime()
             }
             val effect = when (currentState.dialogState) {
-                DialogState.HOME_CONNECT -> TrainerHomeSideEffect.NavigateToInvite
-                DialogState.ADD_PT_CONNECT -> TrainerHomeSideEffect.NavigateToInvite
+                TrainerHomeDialog.HomeConnect -> TrainerHomeSideEffect.NavigateToInvite
+                TrainerHomeDialog.AddPtConnect -> TrainerHomeSideEffect.NavigateToInvite
                 else -> return
             }
             updateState {
-                copy(dialogState = DialogState.NONE, isDialogHiddenForThreeDays = false)
+                copy(
+                    dialogState = TrainerHomeDialog.None,
+                    isDialogHiddenForThreeDays = false,
+                )
             }
             sendEffect(effect)
         }
@@ -230,7 +245,7 @@ internal class TrainerHomeViewModel @Inject constructor(
             }
             updateState {
                 copy(
-                    dialogState = DialogState.NONE,
+                    dialogState = TrainerHomeDialog.None,
                     isDialogHiddenForThreeDays = false,
                 )
             }

--- a/feature/trainer/home/src/main/res/values/strings.xml
+++ b/feature/trainer/home/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="no_pt_session_yet">아직 등록된 수업이 없어요.</string>
     <string name="press_add_button_to_add_pt_session">추가 버튼을 눌러 PT 수업 일정을 추가해 보세요</string>
     <string name="pt_session_count">%1$s회차 수업</string>
+    <string name="pt_early_completion_title">수업을 기록하시겠어요?</string>
+    <string name="pt_early_completion_message">아직 수업 시간이 지나지 않았어요</string>
 </resources>


### PR DESCRIPTION
## 📝 작업 내용

- Closes #140 

</br>

- 요구사항이 변경됨에 따라 트레이너 홈 화면의 월간 캘린더를 주간 캘린더로 전환하였습니다.
- 실제 수업 시작 전, 트레이너가 임의로 '수업 완료' 버튼을 누른 경우 경고 다이얼로그를 출력하도록 구현하였습니다.


## 📸 실행 화면

726 × 1436

<img src="https://github.com/user-attachments/assets/a918d4dc-0e5f-449f-b488-b5d7759e45e6" width="358" height="718"/>

## 🙆🏻 리뷰 요청 사항

NONE

## 👀 레퍼런스

NONE